### PR TITLE
multipart: proposal for concurrent API

### DIFF
--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -66,7 +66,7 @@ class Config(StorageModel):
     proxy_info: Optional[ProxyInfo] = None
 
 
-class AzureTransfer(BaseTransfer[Config]):
+class AzureTransfer(BaseTransfer[Config]):  # pylint: disable=abstract-method
     config_model = Config
 
     def __init__(

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -180,7 +180,7 @@ class Config(StorageModel):
 ResType = TypeVar("ResType")
 
 
-class GoogleTransfer(BaseTransfer[Config]):
+class GoogleTransfer(BaseTransfer[Config]):  # pylint: disable=abstract-method
     config_model = Config
 
     def __init__(

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -39,7 +39,7 @@ class Config(StorageModel):
     prefix: Optional[str] = None
 
 
-class LocalTransfer(BaseTransfer[Config]):
+class LocalTransfer(BaseTransfer[Config]):  # pylint: disable=abstract-method
     config_model = Config
 
     is_thread_safe = True

--- a/rohmu/util.py
+++ b/rohmu/util.py
@@ -4,9 +4,10 @@ rohmu - common utility functions
 Copyright (c) 2022 Ohmu Ltd
 See LICENSE for details
 """
+from io import BytesIO
 from itertools import islice
 from rohmu.typing import HasFileno
-from typing import Generator, Iterable, Optional, Tuple, TypeVar, Union
+from typing import BinaryIO, Generator, Iterable, Optional, Tuple, TypeVar, Union
 
 import fcntl
 import logging
@@ -71,3 +72,41 @@ def get_total_size_from_content_range(content_range: str) -> Optional[int]:
     length = content_range.rsplit("/", 1)[1]
     # RFC 9110 section 14.4 specifies that the * can be returned when the total length is unknown
     return int(length) if length != "*" else None
+
+
+class BinaryStreamsConcatenation:
+    """Concatenate a sequence of binary streams.
+
+    The concatenation only allows for the read() call.
+    """
+
+    def __init__(self, files: Iterable[BinaryIO]) -> None:
+        self._iter_files = iter(files)
+        self._current_file: Optional[BinaryIO] = None
+
+    def _read_chunk(self, size: int = -1) -> bytes:
+        if self._current_file is None:
+            self._current_file = next(self._iter_files, None)
+            if self._current_file is None:
+                return b""
+        data = self._current_file.read(size) if size > 0 else self._current_file.read()
+        if not data:
+            self._current_file.close()
+            self._current_file = next(self._iter_files, None)
+        return data
+
+    def read(self, size: int = -1) -> bytes:
+        result = BytesIO()
+        size_left = size
+        while True:
+            chunk = self._read_chunk(size_left)
+            if not chunk and self._current_file is None:
+                # we finished reading all files
+                break
+            result.write(chunk)
+            size_left -= len(chunk)
+            if size > 0 and size_left == 0:
+                # we finished reading the amount requested
+                break
+
+        return result.getvalue()

--- a/test/test_object_storage_local.py
+++ b/test/test_object_storage_local.py
@@ -1,11 +1,13 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
-from rohmu.errors import InvalidByteRangeError
+from rohmu.errors import FileNotFoundFromStorageError, InvalidByteRangeError, StorageError
 from rohmu.object_storage.base import KEY_TYPE_OBJECT
 from rohmu.object_storage.local import LocalTransfer
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest.mock import MagicMock
 
+import hashlib
 import json
 import os
 import pytest
@@ -102,6 +104,201 @@ def test_can_handle_metadata_without_md5() -> None:
             "name": "test_key1",
             "size": len(test_data),
             "metadata": old_metadata,
+        }
+        last_modified = result.pop("last_modified")
+        assert last_modified is not None
+        assert result == expected_value
+
+
+def test_can_upload_files_concurrently() -> None:
+    with TemporaryDirectory() as destdir, TemporaryDirectory() as mpu_tmpdir:
+        notifier = MagicMock()
+        transfer = LocalTransfer(
+            directory=destdir,
+            notifier=notifier,
+            concurrent_upload_directory=mpu_tmpdir,
+        )
+        upload = transfer.create_concurrent_upload(key="test_key1", metadata={"some-key": "some-value"})
+        # should end up with b"Hello, World!\nHello, World!"
+        expected_data = b"Hello, World!\nHello, World!"
+        upload.upload_chunk(3, BytesIO(b"Hello"))
+        upload.upload_chunk(4, BytesIO(b", "))
+        upload.upload_chunk(1, BytesIO(b"Hello, World!"))
+        upload.upload_chunk(7, BytesIO(b"!"))
+        upload.upload_chunk(2, BytesIO(b"\n"))
+        upload.upload_chunk(6, BytesIO(b"ld"))
+        upload.upload_chunk(5, BytesIO(b"Wor"))
+        upload.complete()
+
+        # we can read the metadata
+        assert transfer.get_metadata_for_key("test_key1") == {"some-key": "some-value"}
+        # and we can also load the file information iterating over the storage
+        item = next(transfer.iter_key("test_key1", with_metadata=True, include_key=True))
+        assert item.type == KEY_TYPE_OBJECT
+        result = item.value
+        assert isinstance(result, dict)
+
+        hasher = hashlib.sha256()
+        hasher.update(expected_data)
+        md5 = hasher.hexdigest()  # yes, currently we return an "md5" that is really the sha256 of the contents.
+        expected_value = {
+            "md5": md5,
+            "name": "test_key1",
+            "size": len(expected_data),
+            "metadata": {"some-key": "some-value"},
+        }
+        last_modified = result.pop("last_modified")
+        assert last_modified is not None
+        assert result == expected_value
+        # after completion of the upload we have cleaned up the temporary storage
+        assert not os.path.exists(upload._upload_tmp_dir)  # type: ignore [attr-defined] # pylint: disable=protected-access
+
+        # calling complete again does nothing
+        upload.complete()
+
+        with pytest.raises(StorageError):
+            upload.abort()
+
+        with pytest.raises(StorageError):
+            upload.upload_chunk(10, BytesIO(b"more data"))
+
+
+def test_can_upload_files_concurrently_with_threads() -> None:
+    with TemporaryDirectory() as destdir, TemporaryDirectory() as mpu_tmpdir:
+        notifier = MagicMock()
+        transfer = LocalTransfer(
+            directory=destdir,
+            notifier=notifier,
+            concurrent_upload_directory=mpu_tmpdir,
+        )
+        upload = transfer.create_concurrent_upload(key="test_key1", metadata={"some-key": "some-value"})
+        # should end up with b"Hello, World!\nHello, World!"
+        expected_data = b"Hello, World!\nHello, World!"
+
+        with ThreadPoolExecutor() as pool:
+            pool.map(
+                upload.upload_chunk,
+                [3, 4, 1, 7, 2, 6, 5],
+                [
+                    BytesIO(b"Hello"),
+                    BytesIO(b", "),
+                    BytesIO(b"Hello, World!"),
+                    BytesIO(b"!"),
+                    BytesIO(b"\n"),
+                    BytesIO(b"ld"),
+                    BytesIO(b"Wor"),
+                ],
+            )
+
+        upload.complete()
+
+        # we can read the metadata
+        assert transfer.get_metadata_for_key("test_key1") == {"some-key": "some-value"}
+        # and we can also load the file information iterating over the storage
+        item = next(transfer.iter_key("test_key1", with_metadata=True, include_key=True))
+        assert item.type == KEY_TYPE_OBJECT
+        result = item.value
+        assert isinstance(result, dict)
+
+        hasher = hashlib.sha256()
+        hasher.update(expected_data)
+        md5 = hasher.hexdigest()  # yes, currently we return an "md5" that is really the sha256 of the contents.
+        expected_value = {
+            "md5": md5,
+            "name": "test_key1",
+            "size": len(expected_data),
+            "metadata": {"some-key": "some-value"},
+        }
+        last_modified = result.pop("last_modified")
+        assert last_modified is not None
+        assert result == expected_value
+        # after completion of the upload we have cleaned up the temporary storage
+        assert not os.path.exists(upload._upload_tmp_dir)  # type: ignore [attr-defined] # pylint: disable=protected-access
+
+
+def test_upload_files_concurrently_can_be_aborted() -> None:
+    with TemporaryDirectory() as destdir, TemporaryDirectory() as mpu_tmpdir:
+        notifier = MagicMock()
+        transfer = LocalTransfer(
+            directory=destdir,
+            notifier=notifier,
+            concurrent_upload_directory=mpu_tmpdir,
+        )
+        upload = transfer.create_concurrent_upload(key="test_key1", metadata={"some-key": "some-value"})
+        # should end up with b"Hello, World!\nHello, World!"
+        upload.upload_chunk(3, BytesIO(b"Hello"))
+        upload.upload_chunk(4, BytesIO(b", "))
+        upload.upload_chunk(1, BytesIO(b"Hello, World!"))
+        upload.upload_chunk(7, BytesIO(b"!"))
+        upload.upload_chunk(2, BytesIO(b"\n"))
+        upload.upload_chunk(6, BytesIO(b"ld"))
+        upload.upload_chunk(5, BytesIO(b"Wor"))
+        upload.abort()
+
+        # we should not be able to find this
+        with pytest.raises(FileNotFoundFromStorageError):
+            transfer.get_metadata_for_key("test_key1")
+
+        # after abort of the upload we have cleaned up the temporary storage
+        assert not os.path.exists(upload._upload_tmp_dir)  # type: ignore [attr-defined] # pylint: disable=protected-access
+
+        # calling abort again does nothing
+        upload.abort()
+
+        with pytest.raises(StorageError):
+            upload.complete()
+
+        with pytest.raises(StorageError):
+            upload.upload_chunk(10, BytesIO(b"more data"))
+
+
+def test_concurrent_upload_can_be_resumed() -> None:
+    with TemporaryDirectory() as destdir, TemporaryDirectory() as mpu_tmpdir:
+        notifier = MagicMock()
+        transfer = LocalTransfer(
+            directory=destdir,
+            notifier=notifier,
+            concurrent_upload_directory=mpu_tmpdir,
+        )
+        upload = transfer.create_concurrent_upload(key="test_key1", metadata={"some-key": "some-value"})
+        # should end up with b"Hello, World!\nHello, World!"
+        expected_data = b"Hello, World!\nHello, World!"
+        upload.upload_chunk(3, BytesIO(b"Hello"))
+        upload.upload_chunk(4, BytesIO(b", "))
+        upload.upload_chunk(1, BytesIO(b"Hello, World!"))
+
+        new_transfer = LocalTransfer(
+            directory=destdir,
+            notifier=notifier,
+            concurrent_upload_directory=mpu_tmpdir,
+        )
+        new_upload = new_transfer.get_concurrent_upload(upload.upload_id)
+
+        # client can check which chunks were uploaded previously and complete the upload
+        previously_uploaded_chunks = new_upload.list_uploaded_chunks()
+        assert list(previously_uploaded_chunks) == [1, 3, 4]
+        new_upload.upload_chunk(7, BytesIO(b"!"))
+        new_upload.upload_chunk(2, BytesIO(b"\n"))
+        new_upload.upload_chunk(6, BytesIO(b"ld"))
+        new_upload.upload_chunk(5, BytesIO(b"Wor"))
+        new_upload.complete()
+
+        # we can read the metadata
+        assert new_transfer.get_metadata_for_key("test_key1") == {"some-key": "some-value"}
+        # and we can also load the file information iterating over the storage
+        item = next(new_transfer.iter_key("test_key1", with_metadata=True, include_key=True))
+        assert item.type == KEY_TYPE_OBJECT
+        result = item.value
+        assert isinstance(result, dict)
+
+        hasher = hashlib.sha256()
+        hasher.update(expected_data)
+        md5 = hasher.hexdigest()
+        expected_value = {
+            "md5": md5,
+            "name": "test_key1",
+            "size": len(expected_data),
+            "metadata": {"some-key": "some-value"},
         }
         last_modified = result.pop("last_modified")
         assert last_modified is not None

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,4 +1,7 @@
-from rohmu.util import get_total_size_from_content_range
+from __future__ import annotations
+
+from io import BytesIO
+from rohmu.util import BinaryStreamsConcatenation, get_total_size_from_content_range
 from typing import Optional
 
 import pytest
@@ -15,3 +18,26 @@ import pytest
 )
 def test_get_total_size_from_content_range(content_range: str, result: Optional[int]) -> None:
     assert get_total_size_from_content_range(content_range) == result
+
+
+@pytest.mark.parametrize(
+    "input_file_contents,chunk_size,expected_outputs",
+    [
+        ([b"Hello, World!"], 3, [b"Hel", b"lo,", b" Wo", b"rld", b"!"]),
+        ([b"Hello", b", ", b"World", b"!"], 3, [b"Hel", b"lo,", b" Wo", b"rld", b"!"]),
+        ([b"Hello", b", ", b"World", b"!"], -1, [b"Hello, World!"]),
+        ([b"a" * 256 * 1024, b"b" * 128 * 1024], 1024, [b"a" * 1024] * 256 + [b"b" * 1024] * 128),
+        ([b""], 1, []),
+        ([b""] * 10, 1, []),
+        ([b""] * 10, -1, []),
+    ],
+)
+def test_binary_stream_concatenation(
+    input_file_contents: list[bytes], chunk_size: int, expected_outputs: list[bytes]
+) -> None:
+    inputs = [BytesIO(content) for content in input_file_contents]
+    concatenation = BinaryStreamsConcatenation(inputs)
+    outputs = []
+    for output_chunk in iter(lambda: concatenation.read(chunk_size), b""):
+        outputs.append(output_chunk)
+    assert outputs == expected_outputs


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
New API to perform multipart uploads allowing concurrent & non-monotonic upload of chunks.

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

Currently we do use multipart uploads to upload big files, but this is done serially by uploading one part at a time in monotonically increasing order. This limits concurrency.

In order to allow the clients to upload multiple parts concurrently we need to somehow expose the concept of a concurrent upload.

The API proposed here still hides a little bit of details.

# limits

As far as I can tell the limits for the different providers are:
* AWS S3: 10k chunks of at most 5 GiB
* GCP: 10k chunks of at most 5 GiB
* Azure: 50k chunks of at most 4GiB
* Swift: 1k+ chunks (depending on configuration) of at most 5GiB

I'm not sure if it makes much sense to do smart stuff to avoid the limits, since they are quite close and I'd expect the clients to be able to be configured for reducing the chunks size... 

I'd enforce by default at most 10k chunks and 4GiB per chunk since this should work for AWS/GCP/Azure... swift is configurable so doesn't make much sense to enforce that limit.

