### PR TITLE
object_storage: config models improvements

### DIFF
--- a/rohmu/common/models.py
+++ b/rohmu/common/models.py
@@ -2,14 +2,14 @@
 
 
 from rohmu.common.statsd import StatsdConfig
+from rohmu.common.strenum import StrEnum
 from rohmu.notifier.interface import Notifier
 from typing import Optional
 
-import enum
 import pydantic
 
 
-class StorageOperation(str, enum.Enum):
+class StorageOperation(StrEnum):
     iter_key = "iter_key"
     copy_file = "copy_file"
     delete_key = "delete_key"
@@ -28,11 +28,8 @@ class StorageOperation(str, enum.Enum):
     multipart_aborted = "multipart_aborted"
     multipart_complete = "multipart_complete"
 
-    def __str__(self) -> str:
-        return str(self.value)
 
-
-class ProxyType(str, enum.Enum):
+class ProxyType(StrEnum):
     socks5 = "socks5"
     http = "http"
 

--- a/rohmu/common/models.py
+++ b/rohmu/common/models.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2023 Aiven, Helsinki, Finland. https://aiven.io/
-
-
 from rohmu.common.statsd import StatsdConfig
 from rohmu.common.strenum import StrEnum
 from rohmu.notifier.interface import Notifier
 from typing import Optional
 
+import enum
 import pydantic
 
 
@@ -32,6 +31,16 @@ class StorageOperation(StrEnum):
 class ProxyType(StrEnum):
     socks5 = "socks5"
     http = "http"
+
+
+@enum.unique
+class StorageDriver(StrEnum):
+    azure = "azure"
+    google = "google"
+    local = "local"
+    s3 = "s3"
+    sftp = "sftp"
+    swift = "swift"
 
 
 class RohmuModel(pydantic.BaseModel):
@@ -63,6 +72,7 @@ class ProxyInfo(RohmuModel):
 
 
 class StorageModel(pydantic.BaseModel):
+    storage_type: StorageDriver
     notifier: Optional[Notifier] = None
     statsd_info: Optional[StatsdConfig] = None
 

--- a/rohmu/common/statsd.py
+++ b/rohmu/common/statsd.py
@@ -18,7 +18,7 @@ This is combination of:
 from __future__ import annotations
 
 from contextlib import asynccontextmanager, contextmanager
-from enum import Enum
+from rohmu.common.strenum import StrEnum
 from typing import AsyncIterator, Dict, Iterator, Optional, Union
 
 import pydantic
@@ -26,12 +26,9 @@ import socket
 import time
 
 
-class MessageFormat(str, Enum):
+class MessageFormat(StrEnum):
     datadog = "datadog"
     telegraf = "telegraf"
-
-    def __str__(self) -> str:
-        return str(self.value)
 
 
 Tags = Dict[str, Union[int, str, None]]

--- a/rohmu/common/strenum.py
+++ b/rohmu/common/strenum.py
@@ -1,0 +1,21 @@
+"""
+rohmu - StrEnum
+
+Copyright (c) 2023 Aiven, Helsinki, Finland. https://aiven.io/
+See LICENSE for details
+"""
+from __future__ import annotations
+
+import enum
+
+
+class StrEnum(str, enum.Enum):
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def of(cls, value: str) -> StrEnum | None:
+        try:
+            return cls(value)
+        except ValueError:
+            return None

--- a/rohmu/object_storage/base.py
+++ b/rohmu/object_storage/base.py
@@ -113,7 +113,7 @@ class BaseTransfer(Generic[StorageModelT]):
 
     @classmethod
     def from_model(cls, model: StorageModelT) -> BaseTransfer[StorageModelT]:
-        return cls(**model.dict(by_alias=True))
+        return cls(**model.dict(by_alias=True, exclude={"storage_type"}))
 
     def copy_file(
         self, *, source_key: str, destination_key: str, metadata: Optional[Metadata] = None, **_kwargs: Any

--- a/rohmu/object_storage/config.py
+++ b/rohmu/object_storage/config.py
@@ -77,7 +77,7 @@ SWIFT_SEGMENT_SIZE: Final[int] = 1024 * 1024 * 1024 * 3  # 3 Gi
 
 
 class AzureObjectStorageConfig(StorageModel):
-    bucket_name: str
+    bucket_name: Optional[str]
     account_name: str
     account_key: Optional[str] = Field(None, repr=False)
     sas_token: Optional[str] = Field(None, repr=False)
@@ -89,7 +89,7 @@ class AzureObjectStorageConfig(StorageModel):
 
 class GoogleObjectStorageConfig(StorageModel):
     project_id: str
-    bucket_name: str
+    bucket_name: Optional[str]
     credential_file: Optional[FilePath] = None
     credentials: Optional[Dict[str, Any]] = Field(None, repr=False)
     proxy_info: Optional[ProxyInfo] = None
@@ -112,7 +112,7 @@ class S3AddressingStyle(Enum):
 
 class S3ObjectStorageConfig(StorageModel):
     region: str
-    bucket_name: str
+    bucket_name: Optional[str]
     aws_access_key_id: Optional[str] = None
     aws_secret_access_key: Optional[str] = Field(None, repr=False)
     prefix: Optional[str] = None

--- a/rohmu/object_storage/config.py
+++ b/rohmu/object_storage/config.py
@@ -159,4 +159,5 @@ class SwiftObjectStorageConfig(StorageModel):
     project_domain_name: Optional[str] = None
     service_type: Optional[str] = None
     endpoint_type: Optional[str] = None
+    prefix: Optional[str] = None
     storage_type: Literal[StorageDriver.swift] = StorageDriver.swift

--- a/rohmu/object_storage/config.py
+++ b/rohmu/object_storage/config.py
@@ -9,7 +9,7 @@ See LICENSE for details
 from __future__ import annotations
 
 from enum import Enum, unique
-from pydantic import Field
+from pydantic import DirectoryPath, Field, FilePath
 from rohmu.common.models import ProxyInfo, StorageDriver, StorageModel
 from typing import Any, Dict, Final, Literal, Optional, TypeVar
 
@@ -90,7 +90,7 @@ class AzureObjectStorageConfig(StorageModel):
 class GoogleObjectStorageConfig(StorageModel):
     project_id: str
     bucket_name: str
-    credential_file: Optional[str] = None
+    credential_file: Optional[FilePath] = None
     credentials: Optional[Dict[str, Any]] = Field(None, repr=False)
     proxy_info: Optional[ProxyInfo] = None
     prefix: Optional[str] = None
@@ -98,7 +98,7 @@ class GoogleObjectStorageConfig(StorageModel):
 
 
 class LocalObjectStorageConfig(StorageModel):
-    directory: str
+    directory: DirectoryPath
     prefix: Optional[str] = None
     storage_type: Literal[StorageDriver.local] = StorageDriver.local
 

--- a/rohmu/object_storage/config.py
+++ b/rohmu/object_storage/config.py
@@ -9,6 +9,7 @@ See LICENSE for details
 from __future__ import annotations
 
 from enum import Enum, unique
+from pydantic import Field
 from rohmu.common.models import ProxyInfo, StorageDriver, StorageModel
 from typing import Any, Dict, Final, Literal, Optional, TypeVar
 
@@ -78,8 +79,8 @@ SWIFT_SEGMENT_SIZE: Final[int] = 1024 * 1024 * 1024 * 3  # 3 Gi
 class AzureObjectStorageConfig(StorageModel):
     bucket_name: str
     account_name: str
-    account_key: Optional[str] = None
-    sas_token: Optional[str] = None
+    account_key: Optional[str] = Field(None, repr=False)
+    sas_token: Optional[str] = Field(None, repr=False)
     prefix: Optional[str] = None
     azure_cloud: Optional[str] = None
     proxy_info: Optional[ProxyInfo] = None
@@ -90,7 +91,7 @@ class GoogleObjectStorageConfig(StorageModel):
     project_id: str
     bucket_name: str
     credential_file: Optional[str] = None
-    credentials: Optional[Dict[str, Any]] = None
+    credentials: Optional[Dict[str, Any]] = Field(None, repr=False)
     proxy_info: Optional[ProxyInfo] = None
     prefix: Optional[str] = None
     storage_type: Literal[StorageDriver.google] = StorageDriver.google
@@ -113,7 +114,7 @@ class S3ObjectStorageConfig(StorageModel):
     region: str
     bucket_name: str
     aws_access_key_id: Optional[str] = None
-    aws_secret_access_key: Optional[str] = None
+    aws_secret_access_key: Optional[str] = Field(None, repr=False)
     prefix: Optional[str] = None
     host: Optional[str] = None
     port: Optional[str] = None
@@ -125,7 +126,7 @@ class S3ObjectStorageConfig(StorageModel):
     proxy_info: Optional[ProxyInfo] = None
     connect_timeout: Optional[str] = None
     read_timeout: Optional[str] = None
-    aws_session_token: Optional[str] = None
+    aws_session_token: Optional[str] = Field(None, repr=False)
     storage_type: Literal[StorageDriver.s3] = StorageDriver.s3
 
 
@@ -133,15 +134,15 @@ class SFTPObjectStorageConfig(StorageModel):
     server: str
     port: int
     username: str
-    password: Optional[str] = None
-    private_key: Optional[str] = None
+    password: Optional[str] = Field(None, repr=False)
+    private_key: Optional[str] = Field(None, repr=False)
     prefix: Optional[str] = None
     storage_type: Literal[StorageDriver.sftp] = StorageDriver.sftp
 
 
 class SwiftObjectStorageConfig(StorageModel):
     user: str
-    key: str
+    key: str = Field(repr=False)
     container_name: str
     auth_url: str
     auth_version: str = "2.0"

--- a/rohmu/object_storage/config.py
+++ b/rohmu/object_storage/config.py
@@ -9,8 +9,8 @@ See LICENSE for details
 from __future__ import annotations
 
 from enum import Enum, unique
-from rohmu.common.models import ProxyInfo, StorageModel
-from typing import Any, Dict, Final, Optional, TypeVar
+from rohmu.common.models import ProxyInfo, StorageDriver, StorageModel
+from typing import Any, Dict, Final, Literal, Optional, TypeVar
 
 import platform
 
@@ -83,6 +83,7 @@ class AzureObjectStorageConfig(StorageModel):
     prefix: Optional[str] = None
     azure_cloud: Optional[str] = None
     proxy_info: Optional[ProxyInfo] = None
+    storage_type: Literal[StorageDriver.azure] = StorageDriver.azure
 
 
 class GoogleObjectStorageConfig(StorageModel):
@@ -92,11 +93,13 @@ class GoogleObjectStorageConfig(StorageModel):
     credentials: Optional[Dict[str, Any]] = None
     proxy_info: Optional[ProxyInfo] = None
     prefix: Optional[str] = None
+    storage_type: Literal[StorageDriver.google] = StorageDriver.google
 
 
 class LocalObjectStorageConfig(StorageModel):
     directory: str
     prefix: Optional[str] = None
+    storage_type: Literal[StorageDriver.local] = StorageDriver.local
 
 
 @unique
@@ -123,6 +126,7 @@ class S3ObjectStorageConfig(StorageModel):
     connect_timeout: Optional[str] = None
     read_timeout: Optional[str] = None
     aws_session_token: Optional[str] = None
+    storage_type: Literal[StorageDriver.s3] = StorageDriver.s3
 
 
 class SFTPObjectStorageConfig(StorageModel):
@@ -132,6 +136,7 @@ class SFTPObjectStorageConfig(StorageModel):
     password: Optional[str] = None
     private_key: Optional[str] = None
     prefix: Optional[str] = None
+    storage_type: Literal[StorageDriver.sftp] = StorageDriver.sftp
 
 
 class SwiftObjectStorageConfig(StorageModel):
@@ -153,3 +158,4 @@ class SwiftObjectStorageConfig(StorageModel):
     project_domain_name: Optional[str] = None
     service_type: Optional[str] = None
     endpoint_type: Optional[str] = None
+    storage_type: Literal[StorageDriver.swift] = StorageDriver.swift


### PR DESCRIPTION
# About this change - What it does

- common: introduce StrEnum class
- object_storage: introduce `StorageDriver` enum
- object_storage: hide object storage config secrets in representation
- object_storage: make object storage config field types more precise
- object_storage: split object storage config models

# Why this way

To allow downstream use rohmu configs instead of code duplication. See commit messages for more info.

