### PR TITLE
Add support for bucket to bucket copy

### DIFF
--- a/rohmu/object_storage/base.py
+++ b/rohmu/object_storage/base.py
@@ -10,13 +10,28 @@ from __future__ import annotations
 from contextlib import suppress
 from dataclasses import dataclass, field
 from io import BytesIO
+from rohmu.common.models import StorageModel
 from rohmu.common.statsd import StatsClient, StatsdConfig
 from rohmu.errors import FileNotFoundFromStorageError, InvalidByteRangeError, StorageError
 from rohmu.notifier.interface import Notifier
 from rohmu.notifier.null import NullNotifier
 from rohmu.object_storage.config import StorageModelT
 from rohmu.typing import AnyPath, Metadata
-from typing import Any, BinaryIO, Callable, Collection, Generic, Iterator, NamedTuple, Optional, Protocol, Tuple, Type, Union
+from typing import (
+    Any,
+    BinaryIO,
+    Callable,
+    Collection,
+    Generic,
+    Iterator,
+    NamedTuple,
+    Optional,
+    Protocol,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import logging
 import os
@@ -44,6 +59,9 @@ class ConcurrentUpload:
     key: str
     metadata: Optional[Metadata]
     chunks_to_etags: dict[int, str] = field(default_factory=dict, hash=False, compare=False)
+
+
+SourceStorageModelT = TypeVar("SourceStorageModelT", bound=StorageModel)
 
 
 class BaseTransfer(Generic[StorageModelT]):
@@ -120,6 +138,9 @@ class BaseTransfer(Generic[StorageModelT]):
     ) -> None:
         """Performs remote copy from source key name to destination key name. Key must identify a file, trees
         cannot be copied with this method. If no metadata is given copies the existing metadata."""
+        raise NotImplementedError
+
+    def copy_files_from(self, *, source: BaseTransfer[SourceStorageModelT], keys: Collection[str]) -> None:
         raise NotImplementedError
 
     def format_key_for_backend(self, key: str, remove_slash_prefix: bool = False, trailing_slash: bool = False) -> str:

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -21,11 +21,12 @@ from rohmu.object_storage.base import (
     KEY_TYPE_OBJECT,
     KEY_TYPE_PREFIX,
     ProgressProportionCallbackType,
+    SourceStorageModelT,
 )
 from rohmu.object_storage.config import LOCAL_CHUNK_SIZE as CHUNK_SIZE, LocalObjectStorageConfig as Config
 from rohmu.typing import Metadata
 from rohmu.util import BinaryStreamsConcatenation, ProgressStream
-from typing import Any, BinaryIO, Iterator, Optional, TextIO, Tuple, Union
+from typing import Any, BinaryIO, Collection, Iterator, Optional, TextIO, Tuple, Union
 
 import contextlib
 import datetime
@@ -60,7 +61,14 @@ class LocalTransfer(BaseTransfer[Config]):
     def copy_file(
         self, *, source_key: str, destination_key: str, metadata: Optional[Metadata] = None, **_kwargs: Any
     ) -> None:
-        source_path = self.format_key_for_backend(source_key.strip("/"))
+        self._copy_file_from_bucket(
+            source_bucket=self, source_key=source_key, destination_key=destination_key, metadata=metadata
+        )
+
+    def _copy_file_from_bucket(
+        self, *, source_bucket: LocalTransfer, source_key: str, destination_key: str, metadata: Optional[Metadata] = None
+    ) -> None:
+        source_path = source_bucket.format_key_for_backend(source_key.strip("/"))
         destination_path = self.format_key_for_backend(destination_key.strip("/"))
         if not os.path.isfile(source_path):
             raise FileNotFoundFromStorageError(source_key)
@@ -73,6 +81,13 @@ class LocalTransfer(BaseTransfer[Config]):
             new_metadata.update(metadata)
             self._save_metadata(destination_path, new_metadata)
         self.notifier.object_copied(key=destination_key, size=os.path.getsize(destination_path), metadata=metadata)
+
+    def copy_files_from(self, *, source: BaseTransfer[SourceStorageModelT], keys: Collection[str]) -> None:
+        if isinstance(source, LocalTransfer):
+            for key in keys:
+                self._copy_file_from_bucket(source_bucket=source, source_key=key, destination_key=key)
+        else:
+            raise NotImplementedError
 
     def _get_metadata_for_key(self, key: str) -> Metadata:
         source_path = self.format_key_for_backend(key.strip("/"))

--- a/test/object_storage/test_object_storage.py
+++ b/test/object_storage/test_object_storage.py
@@ -69,6 +69,20 @@ def test_copy(transfer_type: str, request: Any) -> None:
     assert transfer.get_contents_to_string("dummy_copy_metadata") == (DUMMY_CONTENT, {"new_k": "new_v"})
 
 
+def test_copy_local_files_from(tmp_path: Path) -> None:
+    source = LocalTransfer(tmp_path / "source", prefix="s-prefix")
+    destination = LocalTransfer(tmp_path / "destination", prefix="d-prefix")
+
+    source.store_file_from_memory("some/a/key.ext", b"content_a", metadata={"info": "aaa"})
+    source.store_file_from_memory("some/b/key.ext", b"content_b", metadata={"info": "bbb"})
+    destination.copy_files_from(
+        source=source,
+        keys=["some/a/key.ext", "some/b/key.ext"],
+    )
+    assert destination.get_contents_to_string("some/a/key.ext") == (b"content_a", {"info": "aaa", "Content-Length": "9"})
+    assert destination.get_contents_to_string("some/b/key.ext") == (b"content_b", {"info": "bbb", "Content-Length": "9"})
+
+
 @pytest.mark.parametrize("transfer_type", ["local_transfer"])
 def test_list(transfer_type: str, request: Any) -> None:
     transfer = request.getfixturevalue(transfer_type)


### PR DESCRIPTION
# About this change - What it does

This adds support for copy of multiple files across different buckets,
for now only if the two buckets are on the same provider.

# Why this way

This enables copying data from bucket to bucket without storing it locally.
