### PR TITLE
Revert "object_storage: make object storage config field types more precise

### DIFF
--- a/rohmu/object_storage/config.py
+++ b/rohmu/object_storage/config.py
@@ -9,6 +9,7 @@ See LICENSE for details
 from __future__ import annotations
 
 from enum import Enum, unique
+from pathlib import Path
 from pydantic import Field
 from rohmu.common.models import ProxyInfo, StorageDriver, StorageModel
 from typing import Any, Dict, Final, Literal, Optional, TypeVar
@@ -90,7 +91,8 @@ class AzureObjectStorageConfig(StorageModel):
 class GoogleObjectStorageConfig(StorageModel):
     project_id: str
     bucket_name: Optional[str]
-    credential_file: Optional[str] = None
+    # Don't use pydantic FilePath, that class checks the file exists at the wrong time
+    credential_file: Optional[Path] = None
     credentials: Optional[Dict[str, Any]] = Field(None, repr=False)
     proxy_info: Optional[ProxyInfo] = None
     prefix: Optional[str] = None
@@ -98,7 +100,8 @@ class GoogleObjectStorageConfig(StorageModel):
 
 
 class LocalObjectStorageConfig(StorageModel):
-    directory: str
+    # Don't use pydantic DirectoryPath, that class checks the dir exists at the wrong time
+    directory: Path
     prefix: Optional[str] = None
     storage_type: Literal[StorageDriver.local] = StorageDriver.local
 

--- a/rohmu/object_storage/config.py
+++ b/rohmu/object_storage/config.py
@@ -9,7 +9,7 @@ See LICENSE for details
 from __future__ import annotations
 
 from enum import Enum, unique
-from pydantic import DirectoryPath, Field, FilePath
+from pydantic import Field
 from rohmu.common.models import ProxyInfo, StorageDriver, StorageModel
 from typing import Any, Dict, Final, Literal, Optional, TypeVar
 
@@ -90,7 +90,7 @@ class AzureObjectStorageConfig(StorageModel):
 class GoogleObjectStorageConfig(StorageModel):
     project_id: str
     bucket_name: Optional[str]
-    credential_file: Optional[FilePath] = None
+    credential_file: Optional[str] = None
     credentials: Optional[Dict[str, Any]] = Field(None, repr=False)
     proxy_info: Optional[ProxyInfo] = None
     prefix: Optional[str] = None
@@ -98,7 +98,7 @@ class GoogleObjectStorageConfig(StorageModel):
 
 
 class LocalObjectStorageConfig(StorageModel):
-    directory: DirectoryPath
+    directory: str
     prefix: Optional[str] = None
     storage_type: Literal[StorageDriver.local] = StorageDriver.local
 


### PR DESCRIPTION
# About this change - What it does

This reverts commit 73fb83b6

# Why this way

This checks that the file or folder exists at the time the config object is created,
it's perfectly valid for the file or folder to not exist when the object is created
and sometimes impossible for that file or folder to exist:

The config may be created in a different environment from where the config
will be used in the end (different chroot, container or server).

Using the object type to validate a property that is actually not part of the
object but part of the external environment is flaky anyway: the environment
will change outside of the control of the object and the property validated
when the object was constructed will become false while the code using
the object will believe that property is still true.
