### PR TITLE
Add py.typed marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ __pycache__/
 coverage.xml
 rohmu-rpm-src.tar
 .hypothesis/
+.mypy_cache/

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,3 +40,5 @@ install_requires =
 [options.packages.find]
 where = .
 include = rohmu*
+[options.package_data]
+* = py.typed


### PR DESCRIPTION
Add a `py.typed` marker so that type hints can be used by mypy in projects that use this library.