### PR TITLE
s3: allow passing cert_path to S3Transfer

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -6,7 +6,7 @@ disallow_incomplete_defs = true
 disallow_subclassing_any = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-
+plugins = pydantic.mypy
 
 [mypy-azure.*]
 ignore_missing_imports = True


### PR DESCRIPTION
Allow passing a certificate to the s3 client.  This is needed for easy interop with MinIO.

Note that this is an option for botocore https://github.com/boto/botocore/blob/develop/botocore/session.py#L874