### PR TITLE
Fix type hints

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -21,3 +21,6 @@ types-mock
 types-requests
 # Extra stubs
 google-api-python-client-stubs
+# Used for their stubs
+zstandard==0.21.0
+python-snappy==0.6.1

--- a/rohmu/atomic_opener.py
+++ b/rohmu/atomic_opener.py
@@ -6,7 +6,7 @@ from typing_extensions import TypeAlias
 try:
     from typing import Literal
 except ImportError:
-    from typing_extensions import Literal  # type: ignore [assignment]
+    from typing_extensions import Literal  # type: ignore[assignment]
 
 import errno
 import os

--- a/rohmu/delta/common.py
+++ b/rohmu/delta/common.py
@@ -103,21 +103,23 @@ class SizeLimitedFile:
     def __enter__(self) -> SizeLimitedFile:
         return self
 
-    def __exit__(self, t: Optional[Type[BaseException]], v: Optional[BaseException], tb: Optional[TracebackType]) -> None:
+    def __exit__(
+        self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
+    ) -> None:
         self._f.close()
 
-    def read(self, n: Optional[int] = None) -> bytes:
+    def read(self, n: int = -1, /) -> bytes:
         can_read = max(0, self._file_size - self._f.tell())
-        if n is None:
+        if n == -1:
             n = can_read
         n = min(can_read, n)
         return self._f.read(n)
 
-    def seek(self, ofs: int, whence: int = 0) -> int:
+    def seek(self, offset: int, whence: int = 0, /) -> int:
         if whence == os.SEEK_END:
-            ofs += self._file_size
+            offset += self._file_size
             whence = os.SEEK_SET
-        return self._f.seek(ofs, whence)
+        return self._f.seek(offset, whence)
 
 
 class SnapshotHash(DeltaModel):

--- a/rohmu/encryptor.py
+++ b/rohmu/encryptor.py
@@ -113,7 +113,7 @@ class EncryptorFile(FileWrap):
         self._check_not_closed()
         return True
 
-    def write(self, data: BinaryData) -> int:  # type: ignore [override]
+    def write(self, data: BinaryData) -> int:  # type: ignore[override]
         """Encrypt and write the given bytes"""
         self._check_not_closed()
         if not data:

--- a/rohmu/encryptor.py
+++ b/rohmu/encryptor.py
@@ -7,7 +7,7 @@ See LICENSE for details
 from .common.constants import IO_BLOCK_SIZE
 from .errors import UninitializedError
 from .filewrap import FileWrap, Sink, Stream
-from .typing import BinaryData, FileLike, HasRead, HasWrite
+from .typing import BinaryData, FileLike, HasRead, HasSeek, HasWrite
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -258,7 +258,7 @@ class DecryptorFile(FileWrap):
         self.state = "OPEN"
 
     @classmethod
-    def _file_size(cls, file: FileLike) -> int:
+    def _file_size(cls, file: HasSeek) -> int:
         current_offset = file.seek(0, os.SEEK_SET)
         file_end_offset = file.seek(0, os.SEEK_END)
         file.seek(current_offset, os.SEEK_SET)

--- a/rohmu/factory.py
+++ b/rohmu/factory.py
@@ -68,10 +68,10 @@ def get_transfer_model(storage_config: Config) -> StorageModel:
 
 def get_transfer(storage_config: Config) -> BaseTransfer[Any]:
     storage_config = storage_config.copy()
-    noitifier_config = storage_config.pop("notifier", None)
+    notifier_config = storage_config.pop("notifier", None)
     notifier = None
-    if noitifier_config is not None:
-        notifier = get_notifier(noitifier_config)
+    if notifier_config is not None:
+        notifier = get_notifier(notifier_config)
     model = get_transfer_model(storage_config)
     return get_transfer_from_model(model, notifier)
 

--- a/rohmu/filewrap.py
+++ b/rohmu/filewrap.py
@@ -88,7 +88,7 @@ class FileWrap(io.BufferedIOBase):
         self._check_not_closed()
         return False
 
-    def write(self, data: BinaryData) -> int:  # type: ignore [override]
+    def write(self, data: BinaryData) -> int:  # type: ignore[override]
         """Encrypt and write the given bytes"""
         self._check_not_closed()
         raise io.UnsupportedOperation("Write not supported")

--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -271,7 +271,7 @@ class AzureTransfer(BaseTransfer[Config]):
         allows reading entire blob into memory at once or returning data from random offsets"""
         file_size = None
         start_range = byte_range[0] if byte_range else 0
-        chunk_size = self.conn._config.max_chunk_get_size  # type: ignore [attr-defined] # pylint: disable=protected-access
+        chunk_size = self.conn._config.max_chunk_get_size  # type: ignore[attr-defined] # pylint: disable=protected-access
         end_range = chunk_size - 1
         blob = self.conn.get_blob_client(self.container_name, key)
         while True:
@@ -362,13 +362,13 @@ class AzureTransfer(BaseTransfer[Config]):
         seekable = hasattr(fd, "seekable") and fd.seekable()
         if not seekable:
             original_tell = getattr(fd, "tell", None)
-            fd.tell = lambda: None  # type: ignore [assignment,method-assign,return-value]
+            fd.tell = lambda: None  # type: ignore[assignment,method-assign,return-value]
         sanitized_metadata = self.sanitize_metadata(metadata, replace_hyphen_with="_")
         try:
             blob_client = self.conn.get_blob_client(self.container_name, path)
             blob_client.upload_blob(
                 fd,
-                blob_type=BlobType.BlockBlob,  # type: ignore [arg-type]
+                blob_type=BlobType.BlockBlob,  # type: ignore[arg-type]
                 content_settings=content_settings,
                 metadata=sanitized_metadata,
                 raw_response_hook=progress_callback,
@@ -378,7 +378,7 @@ class AzureTransfer(BaseTransfer[Config]):
         finally:
             if not seekable:
                 if original_tell is not None:
-                    fd.tell = original_tell  # type: ignore [method-assign]
+                    fd.tell = original_tell  # type: ignore[method-assign]
                 else:
                     delattr(fd, "tell")
 

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -200,9 +200,9 @@ class GoogleTransfer(BaseTransfer[Config]):
             http = build_http()
             if self.proxy_info:
                 if self.proxy_info.get("type") == "socks5":
-                    proxy_type = httplib2.socks.PROXY_TYPE_SOCKS5  # type: ignore [attr-defined]
+                    proxy_type = httplib2.socks.PROXY_TYPE_SOCKS5  # type: ignore[attr-defined]
                 else:
-                    proxy_type = httplib2.socks.PROXY_TYPE_HTTP  # type: ignore [attr-defined]
+                    proxy_type = httplib2.socks.PROXY_TYPE_HTTP  # type: ignore[attr-defined]
 
                 http.proxy_info = httplib2.ProxyInfo(
                     proxy_type,
@@ -235,7 +235,7 @@ class GoogleTransfer(BaseTransfer[Config]):
             if self.gs is None:
                 self.gs = self._init_google_client()
             # https://googleapis.github.io/google-api-python-client/docs/dyn/storage_v1.objects.html
-            self.gs_object_client = self.gs.objects()  # type: ignore [attr-defined] # pylint: disable=no-member
+            self.gs_object_client = self.gs.objects()  # type: ignore[attr-defined] # pylint: disable=no-member
         try:
             yield self.gs_object_client
         except HttpError as ex:
@@ -589,7 +589,7 @@ class GoogleTransfer(BaseTransfer[Config]):
         invalid bucket names ("Invalid bucket name") as well as for invalid
         project ("Invalid argument"), try to handle both gracefully."""
         start_time = time.time()
-        gs_buckets = self.gs.buckets()  # type: ignore [union-attr] # pylint: disable=no-member
+        gs_buckets = self.gs.buckets()  # type: ignore[union-attr] # pylint: disable=no-member
         try:
             request = gs_buckets.get(bucket=bucket_name)
             reporter = Reporter(StorageOperation.head_request)
@@ -638,13 +638,13 @@ class MediaStreamUpload(MediaUpload):
         self._name = name
         self._position: Optional[int] = None
 
-    def chunksize(self) -> int:  # type: ignore [override]
+    def chunksize(self) -> int:  # type: ignore[override]
         return self._chunk_size
 
     def mimetype(self) -> str:
         return self._mime_type
 
-    def size(self) -> Optional[int]:  # type: ignore [override]
+    def size(self) -> Optional[int]:  # type: ignore[override]
         self.peek()
         if len(self._next_chunk) < self.peeksize:
             # The total file size should be returned if we have hit the final chunk.
@@ -666,7 +666,7 @@ class MediaStreamUpload(MediaUpload):
             self._next_chunk = self._read_bytes(self.peeksize - len(self._next_chunk), initial_data=self._next_chunk)
 
     # second parameter is length but baseclass incorrectly names it end
-    def getbytes(self, begin: int, length: int) -> bytes:  # type: ignore [override] # pylint: disable=arguments-renamed
+    def getbytes(self, begin: int, length: int) -> bytes:  # type: ignore[override] # pylint: disable=arguments-renamed
         if begin < (self._position or 0):
             msg = f"Requested position {begin} for {repr(self._name)} precedes already fulfilled position {self._position}"
             raise IndexError(msg)
@@ -703,7 +703,7 @@ class MediaStreamUpload(MediaUpload):
     def has_stream(self) -> bool:
         return False
 
-    def stream(self) -> BinaryIO:  # type: ignore [override]
+    def stream(self) -> BinaryIO:  # type: ignore[override]
         raise NotImplementedError
 
     def _read_bytes(self, length: int, *, initial_data: Optional[bytes] = None) -> bytes:

--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -451,7 +451,7 @@ class S3Transfer(BaseTransfer[Config]):
                     bytes_sent += len(data)
                     if progress_fn:
                         # TODO: change this to incremental progress. Size parameter is currently unused.
-                        progress_fn(bytes_sent, size)  # type: ignore [arg-type]
+                        progress_fn(bytes_sent, size)  # type: ignore[arg-type]
                     break
 
         self.stats.operation(StorageOperation.multipart_complete)

--- a/rohmu/object_storage/sftp.py
+++ b/rohmu/object_storage/sftp.py
@@ -136,7 +136,7 @@ class SFTPTransfer(BaseTransfer[Config]):
                         metadata = None
 
                     last_modified = datetime.datetime.fromtimestamp(
-                        attr.st_mtime, tz=datetime.timezone.utc  # type: ignore [arg-type]
+                        attr.st_mtime, tz=datetime.timezone.utc  # type: ignore[arg-type]
                     )
                     yield IterKeyItem(
                         type=KEY_TYPE_OBJECT,
@@ -160,7 +160,7 @@ class SFTPTransfer(BaseTransfer[Config]):
                 continue
 
             file_key = os.path.join(key.strip("/"), attr.filename)
-            if S_ISDIR(attr.st_mode):  # type: ignore [arg-type]
+            if S_ISDIR(attr.st_mode):  # type: ignore[arg-type]
                 if deep:
                     yield from self.iter_key(file_key, with_metadata=with_metadata, deep=True)
                 else:
@@ -175,7 +175,7 @@ class SFTPTransfer(BaseTransfer[Config]):
                         metadata = None
 
                     last_modified = datetime.datetime.fromtimestamp(
-                        attr.st_mtime, tz=datetime.timezone.utc  # type: ignore [arg-type]
+                        attr.st_mtime, tz=datetime.timezone.utc  # type: ignore[arg-type]
                     )
                     yield IterKeyItem(
                         type=KEY_TYPE_OBJECT,

--- a/rohmu/rohmufile.py
+++ b/rohmu/rohmufile.py
@@ -12,16 +12,16 @@ from .compressor import CompressionFile, DecompressionFile, DecompressSink
 from .encryptor import DecryptorFile, DecryptSink, EncryptorFile
 from .errors import InvalidConfigurationError
 from .filewrap import ThrottleSink
-from .typing import FileLike, HasWrite, Metadata
+from .typing import FileLike, HasRead, HasWrite, Metadata
 from contextlib import suppress
 from inspect import signature
 from rohmu.object_storage.base import IncrementalProgressCallbackType
-from typing import Callable, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import time
 
 
-def _fileobj_name(input_obj: FileLike) -> str:
+def _obj_name(input_obj: Any) -> str:
     if hasattr(input_obj, "name"):
         name = getattr(input_obj, "name")
         return f"open file {repr(name)}"
@@ -133,7 +133,7 @@ def read_file(
             action,
             original_size,
             result_size,
-            _fileobj_name(output_obj),
+            _obj_name(output_obj),
             time.monotonic() - start_time,
         )
 
@@ -159,7 +159,7 @@ def file_writer(
 
 def write_file(
     *,
-    input_obj: FileLike,
+    input_obj: HasRead,
     output_obj: FileLike,
     progress_callback: IncrementalProgressCallbackType = None,
     compression_algorithm: Optional[str] = None,
@@ -208,7 +208,7 @@ def write_file(
             log_func=log_func,
             original_size=original_size,
             result_size=result_size,
-            source_name=_fileobj_name(input_obj),
+            source_name=_obj_name(input_obj),
         )
 
     return original_size, result_size

--- a/rohmu/rohmufile.py
+++ b/rohmu/rohmufile.py
@@ -94,7 +94,7 @@ def _callback_wrapper(progress_callback: IncrementalProgressCallbackType) -> Inc
         return None
     sig = signature(progress_callback)
     if len(sig.parameters) == 0:
-        return lambda f: progress_callback()  # type: ignore [misc,call-arg]
+        return lambda f: progress_callback()  # type: ignore[misc,call-arg]
     return progress_callback
 
 

--- a/rohmu/snappyfile.py
+++ b/rohmu/snappyfile.py
@@ -44,7 +44,7 @@ class SnappyFile(FileWrap):
             self.next_fp.flush()
         super().close()
 
-    def write(self, data: BinaryData) -> int:  # type: ignore [override]
+    def write(self, data: BinaryData) -> int:  # type: ignore[override]
         self._check_not_closed()
         if self.encr is None:
             raise io.UnsupportedOperation("file not open for writing")

--- a/rohmu/typing.py
+++ b/rohmu/typing.py
@@ -7,7 +7,7 @@ try:
     # Remove when dropping support for Python 3.7
     from pickle import PickleBuffer
 except ImportError:
-    PickleBuffer = bytes  # type: ignore [misc,assignment]
+    PickleBuffer = bytes  # type: ignore[misc,assignment]
 import mmap
 
 if TYPE_CHECKING:

--- a/rohmu/typing.py
+++ b/rohmu/typing.py
@@ -39,13 +39,22 @@ class HasFileno(Protocol):
 
 
 class HasRead(Protocol):
-    def read(self, n: Optional[int] = -1) -> bytes:
+    def read(self, n: int = -1, /) -> bytes:
         ...
 
 
 class HasWrite(Protocol):
     def write(self, data: BinaryData) -> int:
         ...
+
+
+class HasSeek(Protocol):
+    def seek(self, offset: int, whence: int = 0, /) -> int:
+        ...
+
+
+class HasName(Protocol):
+    name: str
 
 
 class FileLike(Protocol):
@@ -57,7 +66,7 @@ class FileLike(Protocol):
     ) -> None:
         ...
 
-    def read(self, n: Optional[int] = -1) -> bytes:
+    def read(self, n: int = -1, /) -> bytes:
         ...
 
     def flush(self) -> None:
@@ -75,7 +84,7 @@ class FileLike(Protocol):
     def tell(self) -> int:
         ...
 
-    def seek(self, offset: int, whence: int) -> int:
+    def seek(self, offset: int, whence: int = 0, /) -> int:
         ...
 
 

--- a/rohmu/util.py
+++ b/rohmu/util.py
@@ -191,11 +191,10 @@ class ProgressStream(BinaryIO):
     def tell(self) -> int:
         return self.raw_stream.tell()
 
-    def seek(self, offset: int, whence: int = 0) -> int:
+    def seek(self, offset: int, whence: int = 0, /) -> int:
         """Seek the underlying file if this operation is supported.
 
         NOTE: Calling this method will reset the bytes_read field!
-
         """
         result = self.raw_stream.seek(offset, whence)
 

--- a/rohmu/zstdfile.py
+++ b/rohmu/zstdfile.py
@@ -31,7 +31,7 @@ class _ZstdFileWriter(FileWrap):
         self.next_fp.flush()
         super().close()
 
-    def write(self, data: BinaryData) -> int:  # type: ignore [override]
+    def write(self, data: BinaryData) -> int:  # type: ignore[override]
         self._check_not_closed()
         data_as_bytes = bytes(data)
         compressed_data = self._zstd.compress(data_as_bytes)

--- a/test/test_atomic_opener.py
+++ b/test/test_atomic_opener.py
@@ -23,7 +23,7 @@ def test_error_thrown_if_final_path_parent_doesnt_exist(tmp_path: Path) -> None:
 
 def test_error_mode_doesnt_contain_write(tmp_path: Path) -> None:
     with pytest.raises(ValueError):
-        with atomic_opener(tmp_path, mode="r"):  # type: ignore [call-overload]
+        with atomic_opener(tmp_path, mode="r"):  # type: ignore[call-overload]
             pass
 
 
@@ -138,7 +138,7 @@ def test_no_fd_leak_if_fdopen_fails_because_of_unknown_mode(tmp_path: Path) -> N
     try:
         with atomic_opener(
             final_path, mode="somethingrandomw", encoding="ascii", _fd_spy=opened_fd.append
-        ):  # type: ignore [call-overload]
+        ):  # type: ignore[call-overload]
             pass
         pytest.fail("should fail, mode is wrong")
     except ValueError:

--- a/test/test_encryptor.py
+++ b/test/test_encryptor.py
@@ -4,7 +4,7 @@ See LICENSE for details
 """
 from __future__ import annotations
 
-from py.path import LocalPath  # type: ignore [import] # pylint: disable=import-error
+from py.path import LocalPath  # type: ignore[import] # pylint: disable=import-error
 from rohmu.common.constants import IO_BLOCK_SIZE
 from rohmu.encryptor import Decryptor, DecryptorFile, Encryptor, EncryptorFile, EncryptorStream
 from typing import cast, IO

--- a/test/test_rohmufile.py
+++ b/test/test_rohmufile.py
@@ -11,7 +11,7 @@ import pytest
 
 def test_fileobj_name(tmpdir: Any) -> None:
     with NamedTemporaryFile(dir=tmpdir, suffix="foo") as raw_output_obj:
-        result = rohmufile._fileobj_name(raw_output_obj)  # type: ignore # pylint: disable=protected-access
+        result = rohmufile._fileobj_name(raw_output_obj)  # type: ignore# pylint: disable=protected-access
         assert result.startswith("open file ")
         assert "foo" in result
 

--- a/test/test_rohmufile.py
+++ b/test/test_rohmufile.py
@@ -11,7 +11,7 @@ import pytest
 
 def test_fileobj_name(tmpdir: Any) -> None:
     with NamedTemporaryFile(dir=tmpdir, suffix="foo") as raw_output_obj:
-        result = rohmufile._fileobj_name(raw_output_obj)  # type: ignore# pylint: disable=protected-access
+        result = rohmufile._obj_name(raw_output_obj)  # type: ignore# pylint: disable=protected-access
         assert result.startswith("open file ")
         assert "foo" in result
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
This fixes some type hint issues that are preventing downstream projects from passing CI.

<!-- Provide a small sentence that summarizes the change. -->

This contains the following changes:

- `SizeLimitedFile` uses common conventions, types and defaults.
- `_fileobj_name` -> `_obj_name`, as it's not related to files.
- `rohmufile.write_file` only requires `HasRead` for the input file.
- `HasRead`, `HasWrite` use Python conventions, types and defaults.
- `FileLike` uses Python conventions, types and defaults.
- New `HasName`.

<!-- Provide the issue number below if it exists. -->

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

