### PR TITLE
Bump to version 2.1.0

### DIFF
--- a/rohmu/version.py
+++ b/rohmu/version.py
@@ -1,1 +1,1 @@
-VERSION = "2.0.1"
+VERSION = "2.1.0"


### PR DESCRIPTION
The minor is being bumped, as it is not fully backward compatible with 2.0.1.
