### PR TITLE
Fix documentation

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -42,6 +42,6 @@ jobs:
         test $(git for-each-ref --format='%(objecttype)' ${GITHUB_REF}) == tag
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ mypy:
 fmt:
 	isort $(PYTHON_SOURCE_DIRS)
 	black $(PYTHON_SOURCE_DIRS)
-	$(PYTHON) -m rstfmt README.rst -w 100
+	$(PYTHON) -m rstfmt README.rst docs/*.rst -w 100
 
 .PHONY: coverage
 coverage:

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,10 @@
+#######
+ Rohmu
+#######
+
+..
+   start-include-intro
+
 |Rohmu logo|
 
 |Build badge| |PyPI badge| |Python versions badge|
@@ -8,36 +15,82 @@ supports main public clouds such as GCP, AWS, and Azure for backup storage. Rohm
 backup tools such as PGHoard_ for PostgreSQL, MyHoard_ for MySQL, and Astacus_ for M3, ClickHouse,
 and other databases.
 
-##########
+..
+   end-include-intro
+
+..
+   start-include-features
+
+**********
  Features
-##########
+**********
 
 -  Supported object storages: Azure, GCP, S3, Swift (OpenStack), local file storage, and SFTP.
 -  Supported compression algorithms: Snappy_, zstd_, and lzma_.
 
-##############
+..
+   end-include-features
+
+..
+   start-include-requirements
+
+**************
  Requirements
-##############
+**************
 
 Rohmu requires Python >= 3.8. For Python library dependencies, refer to setup.cfg_.
 
-###############
+..
+   end-include-requirements
+
+..
+   start-include-usage
+
+***************
  Usage example
-###############
+***************
 
 *Add usage example here*
 
 For real-world usage, see `how Rohmu is used in PGHoard`_.
 
-#############
+..
+   end-include-usage
+
+*************
  Development
-#############
+*************
 
 *TODO*
 
-#########
+..
+   start-include-building-the-package
+
+**********************
+ Building the package
+**********************
+
+To build an installation package for your distribution, go to the root directory of a Rohmu Git
+checkout and run:
+
+Fedora:
+
+.. code::
+
+   sudo make fedora-dev-setup
+   make rpm
+
+This will produce a ``.rpm`` package usually into ``rpm/RPMS/noarch/``.
+
+..
+   end-include-building-the-package
+
+..
+   start-include-license
+
+*********
  License
-#########
+*********
 
 Rohmu is licensed under the Apache license, version 2.0. Full license text is available in the
 LICENSE_ file.
@@ -45,17 +98,23 @@ LICENSE_ file.
 Please note that the project explicitly does not require a CLA (Contributor License Agreement) from
 its contributors.
 
-############
+..
+   end-include-license
+
+..
+   start-include-trademarks-and-credits
+
+************
  Trademarks
-############
+************
 
 PostgreSQL, MySQL, M3 and ClickHouse are trademarks and property of their respective owners. All
 product and service names used in this website are for identification purposes only and do not imply
 endorsement.
 
-#########
+*********
  Credits
-#########
+*********
 
 Rohmu was created by and is maintained by Aiven_.
 
@@ -63,19 +122,37 @@ Rohmu was originally a part of PGHoard_ but was later extracted to its own GitHu
 
 The Rohmu logo was created by `@evche-aiven`_.
 
-#########
+..
+   end-include-trademarks-and-credits
+
+..
+   start-include-contact
+
+*********
  Contact
-#########
+*********
 
 Bug reports and patches are very welcome; please post them as GitHub issues and pull requests at
 rohmu_repo_. To report any possible vulnerabilities or other serious issues, please see our
 security_ policy.
 
-###########
+..
+   end-include-contact
+
+..
+   start-include-copyright
+
+***********
  Copyright
-###########
+***********
 
 Copyright (C) 2023 Aiven Ltd and contributors to the Rohmu project.
+
+..
+   end-include-copyright
+
+..
+   start-include-links
 
 ..
    --------- Links ---------

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -1,12 +1,10 @@
-About Rohmu
-===========
+#############
+ About Rohmu
+#############
 
-Features
---------
+.. include:: ../README.rst
+   :start-after: start-include-features
+   :end-before: end-include-features
 
-*  Supported object storages: Azure, GCP, S3, Swift (OpenStack), local
-   file storage and SFTP.
-*  Supported compression algorithms: Snappy,
-   `zstd <https://github.com/facebook/zstd>`__ and
-   `lzma <https://docs.python.org/3/library/lzma.html>`__.
-
+.. include:: ../README.rst
+   :start-after: start-include-links

--- a/docs/autodoc.rst
+++ b/docs/autodoc.rst
@@ -1,0 +1,141 @@
+##########################
+ Python API Documentation
+##########################
+
+Main Module
+===========
+
+.. automodule:: rohmu
+   :members:
+
+Sub-modules
+===========
+
+.. automodule:: rohmu.atomic_opener
+   :members:
+
+.. automodule:: rohmu.compat
+   :members:
+
+.. automodule:: rohmu.compressor
+   :members:
+
+.. automodule:: rohmu.dates
+   :members:
+
+.. automodule:: rohmu.encryptor
+   :members:
+
+.. automodule:: rohmu.errors
+   :members:
+
+.. automodule:: rohmu.factory
+   :members:
+
+.. automodule:: rohmu.filewrap
+   :members:
+
+.. automodule:: rohmu.inotify
+   :members:
+
+.. automodule:: rohmu.rohmufile
+   :members:
+
+.. automodule:: rohmu.snappyfile
+   :members:
+
+.. automodule:: rohmu.transfer_pool
+   :members:
+
+.. automodule:: rohmu.typing
+   :members:
+
+.. automodule:: rohmu.util
+   :members:
+
+.. automodule:: rohmu.version
+   :members:
+
+.. automodule:: rohmu.zstdfile
+   :members:
+
+Sub-packages
+============
+
+Common Package
+--------------
+
+.. automodule:: rohmu.common
+   :members:
+
+.. automodule:: rohmu.common.constants
+   :members:
+
+.. automodule:: rohmu.common.models
+   :members:
+
+.. automodule:: rohmu.common.statsd
+   :members:
+
+.. automodule:: rohmu.common.strenum
+   :members:
+
+Delta Package
+-------------
+
+.. automodule:: rohmu.delta
+   :members:
+
+.. automodule:: rohmu.delta.common
+   :members:
+
+.. automodule:: rohmu.delta.snapshot
+   :members:
+
+Notifier Package
+----------------
+
+.. automodule:: rohmu.notifier
+   :members:
+
+.. automodule:: rohmu.notifier.http
+   :members:
+
+.. automodule:: rohmu.notifier.interface
+   :members:
+
+.. automodule:: rohmu.notifier.logger
+   :members:
+
+.. automodule:: rohmu.notifier.null
+   :members:
+
+Object Storage Package
+----------------------
+
+.. automodule:: rohmu.object_storage
+   :members:
+
+.. automodule:: rohmu.object_storage.azure
+   :members:
+
+.. automodule:: rohmu.object_storage.base
+   :members:
+
+.. automodule:: rohmu.object_storage.config
+   :members:
+
+.. automodule:: rohmu.object_storage.google
+   :members:
+
+.. automodule:: rohmu.object_storage.local
+   :members:
+
+.. automodule:: rohmu.object_storage.s3
+   :members:
+
+.. automodule:: rohmu.object_storage.sftp
+   :members:
+
+.. automodule:: rohmu.object_storage.swift
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,16 +12,17 @@
 #
 import os
 import sys
+from rohmu.version import VERSION
 
 sys.path.insert(0, os.path.abspath(".."))
 # -- Project information -----------------------------------------------------
 
 project = "Rohmu"
-copyright = "2022, Aiven"
+copyright = "2023, Aiven"
 author = "Aiven"
 
 # The full version, including alpha/beta/rc tags
-release = "1.1.2"
+release = VERSION
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,23 +1,14 @@
-Development
-============
+#############
+ Development
+#############
 
-Requirements
-------------
+.. include:: ../README.rst
+   :start-after: start-include-requirements
+   :end-before: end-include-requirements
 
-Rohmu requires Python >= 3.8. For Python library dependencies, have a
-look at
-`requirements.txt <https://github.com/aiven/rohmu/blob/main/requirements.txt>`__.
+.. include:: ../README.rst
+   :start-after: start-include-building-the-package
+   :end-before: end-include-building-the-package
 
-
-Building the package
---------------------
-
-To build an installation package for your distribution, go to the root
-directory of a Rohmu Git checkout and run:
-
-Fedora::
-
-  sudo make fedora-dev-setup
-  make rpm
-
-This will produce a ``.rpm`` package usually into ``rpm/RPMS/noarch/``.
+.. include:: ../README.rst
+   :start-after: start-include-links

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,72 +1,28 @@
-Rohmu
-=======
+#######
+ Rohmu
+#######
 
-|BuildStatus|
+.. include:: toc.rst
 
-.. |BuildStatus| image:: https://github.com/aiven/rohmu/actions/workflows/build.yml/badge.svg?branch=main
-      :target: https://github.com/aiven/rohmu/actions
-      :alt: Build Status
+.. include:: ../README.rst
+   :start-after: start-include-intro
+   :end-before: end-include-intro
 
-``Rohmu`` is a Python library for building backup tools for databases
-providing functionality for compression, encryption and transferring
-data between the database and an object storage. Rohmu supports main
-public clouds such as GCP, AWS and Azure for backup storage. Rohmu is
-used in various backup tools such as
-`PGHoard <https://github.com/aiven/pghoard>`__ for PostgreSQL,
-`MyHoard <https://github.com/aiven/myhoard>`__ for MySQL and
-`Astacus <https://github.com/aiven/astacus>`__ for M3, ClickHouse and
-other databases.
+.. include:: ../README.rst
+   :start-after: start-include-license
+   :end-before: end-include-license
 
+.. include:: ../README.rst
+   :start-after: start-include-trademarks-and-credits
+   :end-before: end-include-trademarks-and-credits
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Contents
-   :glob:
-   :hidden:
+.. include:: ../README.rst
+   :start-after: start-include-contact
+   :end-before: end-include-contact
 
-   about
-   usage
-   development
+.. include:: ../README.rst
+   :start-after: start-include-copyright
+   :end-before: end-include-copyright
 
-License
-=======
-
-Rohmu is licensed under the Apache license, version 2.0. Full license
-text is available in the `LICENSE <LICENSE>`__ file.
-
-Please note that the project explicitly does not require a CLA
-(Contributor License Agreement) from its contributors.
-
-Trademarks
-==========
-
-PostgreSQL, MySQL, M3 and ClickHouse are trademarks and property of
-their respective owners. All product and service names used in this
-website are for identification purposes only and do not imply
-endorsement.
-
-Credits
-=======
-
-Rohmu was created by and is maintained by `Aiven
-<https://aiven.io>`__.
-
-Rohmu was originally a part of `PGHoard
-<https://github.com/aiven/pghoard>`__ but was later extracted to its
-own GitHub project.
-
-The Rohmu logo was created by `@evche-aiven
-<https://github.com/evche-aiven>`__.
-
-Contact
-=======
-
-Bug reports and patches are very welcome, please post them as GitHub
-issues and pull requests at https://github.com/aiven/rohmu . To report
-any possible vulnerabilities or other serious issues please see our
-`security <SECURITY.md>`__ policy.
-
-Copyright
-=========
-
-Copyright (C) 2022 Aiven Ltd and contributors to the Rohmu project.
+.. include:: ../README.rst
+   :start-after: start-include-links

--- a/docs/toc.rst
+++ b/docs/toc.rst
@@ -1,0 +1,9 @@
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents
+   :hidden:
+
+   autodoc
+   about
+   usage
+   development

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,5 +1,10 @@
-Usage example
-=============
+#######
+ Usage
+#######
 
-For real-world usage you can have a look at `how Rohmu is used in
-PGHoard <https://github.com/aiven/pghoard/blob/main/pghoard/basebackup.py>`__.
+.. include:: ../README.rst
+   :start-after: start-include-usage
+   :end-before: end-include-usage
+
+.. include:: ../README.rst
+   :start-after: start-include-links

--- a/rohmu.spec
+++ b/rohmu.spec
@@ -1,7 +1,7 @@
 Name:           python3-rohmu
 Version:        %{major_version}
 Release:        %{minor_version}%{?dist}
-Url:            https://github.com/aiven/rohmu
+Url:            https://github.com/Aiven-Open/rohmu
 Summary:        Object storage encryption and compression library
 License:        ASL 2.0
 Source0:        rohmu-rpm-src.tar

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -125,15 +125,16 @@ def base64_to_hex(b64val: Union[str, bytes]) -> str:
 
 @dataclasses.dataclass
 class Reporter:
-    """Used for storing default and also reporting them accordingly
+    """Used for storing default and also reporting them accordingly.
 
-    the whole point of this class is to handle different cases
-    - when file size is too small, reporting *_CHUNK_SIZE is wrong as 1000's of
-      small files over a long period (may be a month) is a lot of error
-    - Same is the case of _retry_on_reset
-    - This error extrapolates when replication is being used
+    The whole point of this class is to handle different cases:
 
-    size should ideally be min(real_size, *_CHUNK_SIZE). real_size is avaiable
+    - When file size is too small, reporting ``*_CHUNK_SIZE`` is wrong as 1000's of
+      small files over a long period (may be a month) is a lot of error;
+    - Same is the case of _retry_on_reset;
+    - This error extrapolates when replication is being used.
+
+    Size should ideally be min(real_size, ``*_CHUNK_SIZE``). real_size is avaiable
     when download or upload (from string or file), but when using FD, size is
     not known so assuming something too big for small files is almost wrong and
     in case it is bigger than CHUNKED then status reporting (from the

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,10 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Database :: Database Engines/Servers
     Topic :: Software Development :: Libraries :: Python Modules
-url = https://github.com/aiven/rohmu/
+url = https://github.com/Aiven-Open/rohmu/
 platforms =
     POSIX
     MacOS

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ package_dir =
 packages = find:
 python_requires = >=3.8
 install_requires =
+    azure-common >= 1.1.28, < 2
     azure-storage-blob >= 2.1.0
     botocore
     cryptography
@@ -36,6 +37,7 @@ install_requires =
     pydantic < 2
     python-dateutil
     python-snappy
+    python-swiftclient
     requests
     zstandard
     typing_extensions >= 3.10, < 5


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

I noticed the `docs/`, which seems to not be generated from our `README.rst`, even though it's a copy paste of it. (duplicates stuff).
That means that even though I fixed the links [in a previous PR](https://github.com/Aiven-Open/rohmu/pull/151), this was not reflected on [our docs website](https://aiven-open.github.io/rohmu/).
There was no process for that so far and it was just copy/pasting until now.

## To do

- [ ] change copyrights from docstrings to comments
- [ ] decide on a nice API page hierarchy.