### PR TITLE
object_storage: remove access denied warning for s3 buckets

### DIFF
--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -553,7 +553,8 @@ class S3Transfer(BaseTransfer[Config]):
             if status_code == HTTPStatus.MOVED_PERMANENTLY:
                 raise InvalidConfigurationError(f"Wrong region for bucket {self.bucket_name}, check configuration")
             elif status_code == HTTPStatus.FORBIDDEN:
-                self.log.warning("Access denied on bucket check, assuming write permissions")
+                # Access denied on bucket check, most likely due to missing s3:ListBucket, assuming write permissions
+                pass
             elif status_code in {HTTPStatus.BAD_REQUEST, HTTPStatus.NOT_FOUND}:
                 create_bucket = True
             else:


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
The `Access denied on bucket check` warning messages do not add value, at least they are confusing. A missing `s3:ListBucket` permission does not prohibit writing to a bucket.