### PR TITLE
Fix multipart S3 uploads

### DIFF
--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -447,7 +447,6 @@ class S3Transfer(BaseTransfer[Config]):
                 if progress_fn:
                     # TODO: change this to incremental progress. Size parameter is currently unused.
                     progress_fn(bytes_sent, size)  # type: ignore[arg-type]
-                break
 
         self.stats.operation(StorageOperation.multipart_complete)
         try:


### PR DESCRIPTION
While reworking the retries the nested-loop was removed and this now
causes only the first part to be uploaded.

This adds a test to ensure that it keeps working and also fixes the
issue.