### PR TITLE
Use S3 dualstack endpoint by default

### DIFF
--- a/rohmu/object_storage/config.py
+++ b/rohmu/object_storage/config.py
@@ -151,6 +151,7 @@ class S3ObjectStorageConfig(StorageModel):
     connect_timeout: Optional[str] = None
     read_timeout: Optional[str] = None
     aws_session_token: Optional[str] = Field(None, repr=False)
+    use_dualstack_endpoint: Optional[bool] = True
     storage_type: Literal[StorageDriver.s3] = StorageDriver.s3
 
     @root_validator(skip_on_failure=True)

--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -120,6 +120,7 @@ class S3Transfer(BaseTransfer[Config]):
         read_timeout: Optional[float] = None,
         notifier: Optional[Notifier] = None,
         aws_session_token: Optional[str] = None,
+        use_dualstack_endpoint: Optional[bool] = True,
         statsd_info: Optional[StatsdConfig] = None,
     ) -> None:
         super().__init__(prefix=prefix, notifier=notifier, statsd_info=statsd_info)
@@ -137,6 +138,8 @@ class S3Transfer(BaseTransfer[Config]):
             if proxy_info:
                 proxy_url = get_proxy_url(proxy_info)
                 custom_config["proxies"] = {"https": proxy_url}
+            if use_dualstack_endpoint is True:
+                custom_config["use_dualstack_endpoint"] = True
             self.s3_client = create_s3_client(
                 session=session,
                 config=botocore.config.Config(**custom_config),

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -42,7 +42,10 @@ def test_get_transfer_s3(
 ) -> None:
     expected_config_arg = dict(config)
     expected_config_arg.pop("notifier")
-    expected_botocore_config = {"proxies": {"https": "socks5://bob:secret@proxy.test:16666"}}
+    expected_botocore_config = {
+        "proxies": {"https": "socks5://bob:secret@proxy.test:16666"},
+        "use_dualstack_endpoint": True,
+    }
     mock_config_model.return_value = S3ObjectStorageConfig(**expected_config_arg)
 
     transfer_object = get_transfer(config)


### PR DESCRIPTION
When using the default S3 endpoints, request using dualstack IPv4/IPv6 endpoints.

# About this change - What it does

Configure botocore to utilize dualstack IPv4/IPv6 endpoint for S3. This enables IPv6 only clients to use S3 through rohmu as well.
