### PR TITLE
azure: fix inter-bucket copy not reading from the source bucket

### DIFF
--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -141,7 +141,7 @@ class AzureTransfer(BaseTransfer[Config]):
         timeout: float = 15.0,
     ) -> None:
         source_path = source_bucket.format_key_for_backend(source_key, remove_slash_prefix=True, trailing_slash=False)
-        source_client = source_bucket.conn.get_blob_client(self.container_name, source_path)
+        source_client = source_bucket.conn.get_blob_client(source_bucket.container_name, source_path)
         source_url = source_client.url
 
         destination_path = self.format_key_for_backend(destination_key, remove_slash_prefix=True, trailing_slash=False)


### PR DESCRIPTION
# About this change - What it does

This was trying to copy from the destination to the destination bucket.

Make it copy from the source to the destination.

# Why this way

Because trying to copy from the destination to the destination does not copy the data.
