### PR TITLE
Fix failing Sphinx build due to inability to install dependencies

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -34,7 +34,7 @@ jobs:
           cache: pip
 
       - name: "Install Sphinx & Theme"
-        run: pip install -e '.[docs]'
+        run: pip install -e './main[docs]'
 
       - name: "Run Sphinx"
         run: sphinx-build -b html main/docs gh-pages -E -d $GITHUB_WORKSPACE/.doctree


### PR DESCRIPTION
The checkout being in the main subdirectory, the pip install commands needs to
be adapted accordingly.

Fixes https://github.com/Aiven-Open/rohmu/pull/177