### PR TITLE
replace dateutil with fromisoformat in google backend

### DIFF
--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -22,7 +22,6 @@ from oauth2client import GOOGLE_TOKEN_URI
 from oauth2client.client import GoogleCredentials
 from rohmu.common.models import StorageOperation
 from rohmu.common.statsd import StatsClient, StatsdConfig
-from rohmu.dates import parse_timestamp
 from rohmu.errors import FileNotFoundFromStorageError, InvalidByteRangeError, InvalidConfigurationError
 from rohmu.notifier.interface import Notifier
 from rohmu.object_storage.base import (
@@ -46,6 +45,7 @@ from typing_extensions import Protocol
 
 import codecs
 import dataclasses
+import datetime
 import errno
 
 # NOTE: this import is not needed per-se, but it's imported here first to point the
@@ -387,7 +387,7 @@ class GoogleTransfer(BaseTransfer[Config]):
                         if (size := item.get("size")) is not None:
                             value["size"] = int(size)
                         if (updated := item.get("updated")) is not None:
-                            value["last_modified"] = parse_timestamp(updated)
+                            value["last_modified"] = datetime.datetime.fromisoformat(updated)
                         if (md5 := item.get("md5Hash")) is not None:
                             value["md5"] = base64_to_hex(md5)
                         yield IterKeyItem(type=KEY_TYPE_OBJECT, value=value)


### PR DESCRIPTION
# About this change - What it does

replace dateutil with fromisoformat in google backend.

# Why this way

`dateutil.parser.parse` is particularly slow and covers a lot of use cases that are not relevant to parsing [RFC 3339 datetimes](https://googleapis.github.io/google-api-python-client/docs/dyn/storage_v1.objects.html#list).

This was bad enough that rohmu could eat >50% of CPU while listing entries from Google object storage.

(The next high CPU user is `json.decode`, but that's still far behind `dateutil` and harder to fix since it's inside `googleapiclient`.)

![dateutil_slow](https://github.com/Aiven-Open/rohmu/assets/80679746/a5ada2d0-029e-43ba-8ddc-d6334b27e600)

