### PR TITLE
Close google/azure/s3 client when closing GoogleTransfer object [DDB-1160]

### DIFF
--- a/rohmu/object_storage/base.py
+++ b/rohmu/object_storage/base.py
@@ -82,6 +82,10 @@ class BaseTransfer(Generic[StorageModelT]):
         self.notifier = notifier or NullNotifier()
         self.stats = StatsClient(statsd_info)
 
+    def close(self) -> None:
+        """Release all resources associated with the Transfer object."""
+        pass
+
     @staticmethod
     def _incremental_to_proportional_progress(
         *, size: int, cb: ProgressProportionCallbackType

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -188,9 +188,17 @@ class GoogleTransfer(BaseTransfer[Config]):
         self.proxy_info = proxy_info
         self.google_creds = get_credentials(credential_file=credential_file, credentials=credentials)
         self.gs: Optional[Resource] = self._init_google_client()
-        self.gs_object_client = None
+        self.gs_object_client: Any = None
         self.bucket_name = self.get_or_create_bucket(bucket_name)
         self.log.debug("GoogleTransfer initialized")
+
+    def close(self) -> None:
+        if self.gs_object_client is not None:
+            self.gs_object_client.close()
+            self.gs_object_client = None
+        if self.gs is not None:
+            self.gs.close()
+            self.gs = None
 
     def _init_google_client(self) -> Resource:
         start_time = time.monotonic()

--- a/test/object_storage/test_azure.py
+++ b/test/object_storage/test_azure.py
@@ -25,6 +25,21 @@ def fixture_mock_get_blob_client(mocker: MockerFixture) -> MagicMock:
     return get_blob_client_mock
 
 
+def test_close(mock_get_blob_client: MagicMock) -> None:
+    notifier = MagicMock()
+    transfer = AzureTransfer(
+        bucket_name="test_bucket",
+        account_name="test_account",
+        account_key="test_key1",
+        notifier=notifier,
+    )
+    assert transfer._blob_service_client is not None
+    blob_service_client = transfer._blob_service_client
+    transfer.close()
+    blob_service_client.close.assert_called_once()  # type: ignore[attr-defined]
+    assert transfer._blob_service_client is None
+
+
 def test_store_file_from_disk(mock_get_blob_client: MagicMock) -> None:
     notifier = MagicMock()
     transfer = AzureTransfer(

--- a/test/object_storage/test_s3.py
+++ b/test/object_storage/test_s3.py
@@ -52,6 +52,14 @@ def fixture_infra(mocker: Any) -> Iterator[S3Infra]:
     yield S3Infra(notifier, operation, s3_client, transfer)
 
 
+def test_close(infra: S3Infra) -> None:
+    infra.transfer.get_client()
+    assert infra.transfer.s3_client is not None
+    infra.transfer.close()
+    assert infra.transfer.s3_client is None
+    infra.s3_client.close.assert_called_once()
+
+
 def test_store_file_from_disk(infra: S3Infra) -> None:
     test_data = b"test-data"
     metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -49,11 +49,12 @@ def test_get_transfer_s3(
     mock_config_model.return_value = S3ObjectStorageConfig(**expected_config_arg)
 
     transfer_object = get_transfer(config)
+    assert isinstance(transfer_object, S3Transfer)
+    transfer_object.get_client()
 
     mock_config_model.assert_called_once_with(**expected_config_arg)
     mock_from_model.assert_called_once_with(mock_config_model(), mock_notifier.return_value)
     mock_notifier.assert_called_once_with(url=config["notifier"]["url"])
-    assert isinstance(transfer_object, S3Transfer)
     assert transfer_object.bucket_name == "dummy-bucket"
     mock_botocore_config.assert_called_once_with(**expected_botocore_config)
     mock_s3_client.assert_called_once_with(


### PR DESCRIPTION
# About this change - What it does

GoogleTransfer objects create clients and never close the client, if we create many clients, we leak sockets.

Add a API to close a Transfer object and implement it in the GoogleTransfer subclass to close the google client.

Also implement it in Azure/S3 transfer objects for consistency (and hopefully one day we'll stop creating buckets during `__init__`, which will make the objects creation cheaper and free of side-effects.)

# Why this way

Because if we leak socket, then we eventually crash.