### PR TITLE
Fix release tooling not working

### DIFF
--- a/make_release.py
+++ b/make_release.py
@@ -11,7 +11,7 @@ def make_release(version: str) -> None:
         raise ValueError(f"Unexpected version: {version!r}, should be N.N.N")
     project_directory = Path(__file__).parent
     subprocess.run(
-        ["git", "-C", str(project_directory), "tag", "-s", "-a", f"{version}", "-m", f"Version {version}"],
+        ["git", "-C", str(project_directory), "tag", "-s", "-a", f"releases/{version}", "-m", f"Version {version}"],
         check=True,
     )
     subprocess.run(["git", "-C", str(project_directory), "log", "-n", "1", "-p"], check=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ platforms = [
 
 [tool.hatch.version]
 source = "vcs"
+tag-pattern = "^releases/(?P<version>\\d+.\\d+.\\d+)$"
 
 [tool.hatch.build.hooks.vcs]
 version-file = "rohmu/version.py"


### PR DESCRIPTION
# About this change - What it does

Fix the tooling to be able to make a release.

# Why this way

Because we can't make a release if the tools are broken.