### PR TITLE
Handle deleted buckets gracefully

### DIFF
--- a/rohmu/errors.py
+++ b/rohmu/errors.py
@@ -19,6 +19,18 @@ class InvalidConfigurationError(Error):
     """Invalid configuration"""
 
 
+class TransferObjectStoreInitializationError(Error):
+    """Raised when a transient network or permission issue does not allow us to validate access to the object store"""
+
+
+class TransferObjectStorePermissionError(TransferObjectStoreInitializationError):
+    """Raised when a permission issue does not allow us to validate access to the object store"""
+
+
+class TransferObjectStoreMissingError(TransferObjectStoreInitializationError):
+    """Raised when we know for sure the bucket is missing"""
+
+
 class LocalFileIsRemoteFileError(StorageError):
     """File transfer operation source and destination point to the same file"""
 

--- a/rohmu/factory.py
+++ b/rohmu/factory.py
@@ -66,19 +66,23 @@ def get_transfer_model(storage_config: Config) -> StorageModel:
     return storage_class.config_model(**storage_config)
 
 
-def get_transfer(storage_config: Config) -> BaseTransfer[Any]:
+def get_transfer(storage_config: Config, ensure_object_store_available: bool = True) -> BaseTransfer[Any]:
     storage_config = storage_config.copy()
     notifier_config = storage_config.pop("notifier", None)
     notifier = None
     if notifier_config is not None:
         notifier = get_notifier(notifier_config)
     model = get_transfer_model(storage_config)
-    return get_transfer_from_model(model, notifier)
+    return get_transfer_from_model(model, notifier, ensure_object_store_available=ensure_object_store_available)
 
 
-def get_transfer_from_model(model: StorageModelT, notifier: Optional[Notifier] = None) -> BaseTransfer[StorageModelT]:
+def get_transfer_from_model(
+    model: StorageModelT,
+    notifier: Optional[Notifier] = None,
+    ensure_object_store_available: bool = True,
+) -> BaseTransfer[StorageModelT]:
     storage_class = get_class_for_storage_driver(model.storage_type)
-    return storage_class.from_model(model, notifier)
+    return storage_class.from_model(model, notifier, ensure_object_store_available=ensure_object_store_available)
 
 
 def _to_storage_driver(storage_type: str) -> StorageDriver:

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -50,10 +50,28 @@ class LocalTransfer(BaseTransfer[Config]):
         prefix: Optional[str] = None,
         notifier: Optional[Notifier] = None,
         statsd_info: Optional[StatsdConfig] = None,
+        ensure_object_store_available: bool = True,
     ) -> None:
         prefix = os.path.join(directory, (prefix or "").strip("/"))
-        super().__init__(prefix=prefix, notifier=notifier, statsd_info=statsd_info)
+        super().__init__(
+            prefix=prefix,
+            notifier=notifier,
+            statsd_info=statsd_info,
+            ensure_object_store_available=ensure_object_store_available,
+        )
         self.log.debug("LocalTransfer initialized")
+
+    def _verify_object_storage_unwrapped(self) -> None:
+        """No-op as there's no need to check for the existence of the directory at setup time."""
+
+    def verify_object_storage(self) -> None:
+        """No-op as there's no need to check for the existence of the directory at setup time."""
+
+    def _create_object_store_if_needed_unwrapped(self) -> None:
+        """No-op as there's no need to create the directory ahead of time."""
+
+    def create_object_store_if_needed(self) -> None:
+        """No-op as there's no need to create the directory ahead of time."""
 
     def copy_file(
         self, *, source_key: str, destination_key: str, metadata: Optional[Metadata] = None, **_kwargs: Any

--- a/rohmu/object_storage/sftp.py
+++ b/rohmu/object_storage/sftp.py
@@ -41,8 +41,14 @@ class SFTPTransfer(BaseTransfer[Config]):
         prefix: Optional[str] = None,
         notifier: Optional[Notifier] = None,
         statsd_info: Optional[StatsdConfig] = None,
+        ensure_object_store_available: bool = True,
     ) -> None:
-        super().__init__(prefix=prefix, notifier=notifier, statsd_info=statsd_info)
+        super().__init__(
+            prefix=prefix,
+            notifier=notifier,
+            statsd_info=statsd_info,
+            ensure_object_store_available=ensure_object_store_available,
+        )
         self.server = server
         self.port = port
         self.username = username
@@ -68,6 +74,18 @@ class SFTPTransfer(BaseTransfer[Config]):
         self.client = cast(paramiko.SFTPClient, paramiko.SFTPClient.from_transport(transport))
 
         self.log.debug("SFTPTransfer initialized")
+
+    def _verify_object_storage_unwrapped(self) -> None:
+        """No-op for now. Eventually, the SFTP connection could be tested here instead of in the constructor."""
+
+    def verify_object_storage(self) -> None:
+        """No-op for now. Eventually, the SFTP connection could be tested here instead of in the constructor."""
+
+    def _create_object_store_if_needed_unwrapped(self) -> None:
+        """No-op as it's not applicable to SFTP transfers"""
+
+    def create_object_store_if_needed(self) -> None:
+        """No-op as it's not applicable to SFTP transfers"""
 
     def get_contents_to_fileobj(
         self,

--- a/rohmu/transfer_pool.py
+++ b/rohmu/transfer_pool.py
@@ -135,7 +135,9 @@ class SafeTransfer(BaseTransfer[StorageModel]):
         return super().__getattribute__(attr)
 
     @classmethod
-    def from_model(cls, model: StorageModel, notifier: Optional[Notifier] = None) -> Self:
+    def from_model(
+        cls, model: StorageModel, notifier: Optional[Notifier] = None, ensure_object_store_available: bool = True
+    ) -> Self:
         raise InvalidTransferError("You should not call class methods on SafeTransfer instances")
 
     def return_to_pool(self) -> None:

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -54,7 +54,9 @@ def test_get_transfer_s3(
     transfer_object.get_client()
 
     mock_config_model.assert_called_once_with(**expected_config_arg)
-    mock_from_model.assert_called_once_with(mock_config_model(), mock_notifier.return_value)
+    mock_from_model.assert_called_once_with(
+        mock_config_model(), mock_notifier.return_value, ensure_object_store_available=True
+    )
     mock_notifier.assert_called_once_with(url=config["notifier"]["url"])
     assert transfer_object.bucket_name == "dummy-bucket"
     mock_botocore_config.assert_called_once_with(**expected_botocore_config)


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Introduce the `ensure_object_store_available` parameter to allow creating a transfer object without necessarily creating the backing resources.

When that flag is passed the constructor will not attempt to create missing resources (such as storage buckets), which would allow consumers of the API to handle error cases without having to expose exceptions from rohmu's implementation details.

Instead they can call `verify_object_storage` to check for existence/access, and/or `create_object_store_if_needed` to create the bucket/container if it doesn't already exist.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

This provides a nicer interface to handle potential errors related to network issues/permission issues/etc outside of the constructor. It keeps the current behaviour by default for backwards compatibility.

It's a first step towards untangling the I/O from the initialization process.

This approach avoids adding additional exceptions thrown in the constructor, or alternatively relying even more on the content of the error message string.

An earlier draft of the PR was relying on an `initialized` flag, but new exceptions and methods are more flexible and provide a nicer API.