### PR TITLE
Add progress callback for transferred object keys in copy_files_from

### DIFF
--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -24,7 +24,6 @@ from rohmu.object_storage.base import (
     KEY_TYPE_OBJECT,
     KEY_TYPE_PREFIX,
     ProgressProportionCallbackType,
-    SourceStorageModelT,
 )
 from rohmu.object_storage.config import (  # noqa: F401
     AZURE_ENDPOINT_SUFFIXES as ENDPOINT_SUFFIXES,
@@ -33,7 +32,8 @@ from rohmu.object_storage.config import (  # noqa: F401
     calculate_azure_max_block_size as calculate_max_block_size,
 )
 from rohmu.typing import Metadata
-from typing import Any, BinaryIO, Collection, Iterator, Optional, Tuple, Union
+from typing import Any, BinaryIO, Iterator, Optional, Tuple, Union
+from typing_extensions import Self
 
 import azure.common
 import enum
@@ -182,7 +182,8 @@ class AzureTransfer(BaseTransfer[Config]):
 
     def _copy_file_from_bucket(
         self,
-        source_bucket: AzureTransfer,
+        *,
+        source_bucket: Self,
         source_key: str,
         destination_key: str,
         metadata: Optional[Metadata] = None,
@@ -227,13 +228,6 @@ class AzureTransfer(BaseTransfer[Config]):
                 raise StorageError(
                     f"Copying {repr(source_key)} to {repr(destination_key)} failed, unexpected status: {copy_props.status}"
                 )
-
-    def copy_files_from(self, *, source: BaseTransfer[SourceStorageModelT], keys: Collection[str]) -> None:
-        if isinstance(source, AzureTransfer):
-            for key in keys:
-                self._copy_file_from_bucket(source_bucket=source, source_key=key, destination_key=key, timeout=15)
-        else:
-            raise NotImplementedError
 
     def get_metadata_for_key(self, key: str) -> Metadata:
         path = self.format_key_for_backend(key, remove_slash_prefix=True, trailing_slash=False)

--- a/rohmu/object_storage/base.py
+++ b/rohmu/object_storage/base.py
@@ -56,6 +56,10 @@ ProgressProportionCallbackType = Optional[Callable[[int, int], None]]
 IncrementalProgressCallbackType = Optional[Callable[[int], None]]
 
 
+class ObjectTransferProgressCallback(Protocol):
+    def __call__(self, files_completed: int, total_files: int) -> None: ...
+
+
 @dataclass(frozen=True, unsafe_hash=True)
 class ConcurrentUpload:
     backend: str
@@ -202,10 +206,19 @@ class BaseTransfer(Generic[StorageModelT]):
         cannot be copied with this method. If no metadata is given copies the existing metadata."""
         raise NotImplementedError
 
-    def copy_files_from(self, *, source: BaseTransfer[SourceStorageModelT], keys: Collection[str]) -> None:
+    def copy_files_from(
+        self,
+        *,
+        source: BaseTransfer[Any],
+        keys: Collection[str],
+        progress_fn: ObjectTransferProgressCallback | None = None,
+    ) -> None:
         if isinstance(source, self.__class__):
-            for key in keys:
+            total_files = len(keys)
+            for index, key in enumerate(keys):
                 self._copy_file_from_bucket(source_bucket=source, source_key=key, destination_key=key, timeout=15)
+                if progress_fn is not None:
+                    progress_fn(index + 1, total_files)
         else:
             raise NotImplementedError
 

--- a/rohmu/object_storage/base.py
+++ b/rohmu/object_storage/base.py
@@ -203,6 +203,21 @@ class BaseTransfer(Generic[StorageModelT]):
         raise NotImplementedError
 
     def copy_files_from(self, *, source: BaseTransfer[SourceStorageModelT], keys: Collection[str]) -> None:
+        if isinstance(source, self.__class__):
+            for key in keys:
+                self._copy_file_from_bucket(source_bucket=source, source_key=key, destination_key=key, timeout=15)
+        else:
+            raise NotImplementedError
+
+    def _copy_file_from_bucket(
+        self,
+        *,
+        source_bucket: Self,
+        source_key: str,
+        destination_key: str,
+        metadata: Optional[Metadata] = None,
+        timeout: float = 15.0,
+    ) -> None:
         raise NotImplementedError
 
     def format_key_for_backend(self, key: str, remove_slash_prefix: bool = False, trailing_slash: bool = False) -> str:

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -38,7 +38,6 @@ from rohmu.object_storage.base import (
     KEY_TYPE_OBJECT,
     KEY_TYPE_PREFIX,
     ProgressProportionCallbackType,
-    SourceStorageModelT,
 )
 from rohmu.object_storage.config import (
     GOOGLE_DOWNLOAD_CHUNK_SIZE as DOWNLOAD_CHUNK_SIZE,
@@ -52,7 +51,6 @@ from typing import (
     BinaryIO,
     Callable,
     cast,
-    Collection,
     Iterable,
     Iterator,
     Optional,
@@ -62,7 +60,7 @@ from typing import (
     TypeVar,
     Union,
 )
-from typing_extensions import Protocol
+from typing_extensions import Protocol, Self
 
 import codecs
 import dataclasses
@@ -349,7 +347,13 @@ class GoogleTransfer(BaseTransfer[Config]):
         )
 
     def _copy_file_from_bucket(
-        self, *, source_bucket: GoogleTransfer, source_key: str, destination_key: str, metadata: Optional[Metadata] = None
+        self,
+        *,
+        source_bucket: Self,
+        source_key: str,
+        destination_key: str,
+        metadata: Optional[Metadata] = None,
+        timeout: float = 15.0,
     ) -> None:
         source_object = source_bucket.format_key_for_backend(source_key)
         destination_object = self.format_key_for_backend(destination_key)
@@ -373,13 +377,6 @@ class GoogleTransfer(BaseTransfer[Config]):
                 reporter.size = size
                 self.notifier.object_copied(key=destination_key, size=size, metadata=metadata)
             reporter.report(self.stats)
-
-    def copy_files_from(self, *, source: BaseTransfer[SourceStorageModelT], keys: Collection[str]) -> None:
-        if isinstance(source, GoogleTransfer):
-            for key in keys:
-                self._copy_file_from_bucket(source_bucket=source, source_key=key, destination_key=key)
-        else:
-            raise NotImplementedError
 
     def get_metadata_for_key(self, key: str) -> Metadata:
         path = self.format_key_for_backend(key)


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

This adds a callback function in `copy_files_from`, which provides the transferred object key with completed and total files.

<!-- Provide the issue number below if it exists. -->

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
We want to measure the progress of transferred files. However measuring the amount of transferred bytes requires a provider based implementation. Therefore we measure the keys which is provider independent.
