### PR TITLE
Re-reaise IncompleteReadError as MaybeRecoverableError

### DIFF
--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -5,12 +5,13 @@
 
 from __future__ import annotations
 
-from azure.core.exceptions import HttpResponseError, ResourceExistsError
+from azure.core.exceptions import HttpResponseError, IncompleteReadError, ResourceExistsError
 from azure.storage.blob import BlobServiceClient, ContentSettings
 from rohmu.common.statsd import StatsdConfig
 from rohmu.errors import (
     FileNotFoundFromStorageError,
     InvalidConfigurationError,
+    MaybeRecoverableError,
     StorageError,
     TransferObjectStoreInitializationError,
     TransferObjectStoreMissingError,
@@ -379,6 +380,8 @@ class AzureTransfer(BaseTransfer[Config]):
             self._stream_blob(path, fileobj_to_store_to, byte_range, progress_callback)
         except azure.core.exceptions.ResourceNotFoundError as ex:
             raise FileNotFoundFromStorageError(path) from ex
+        except IncompleteReadError as ex:
+            raise MaybeRecoverableError("IncompleteReadError") from ex
 
         if progress_callback:
             progress_callback(1, 1)

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -889,8 +889,7 @@ class MediaIoBaseDownloadWithByteRange:
         headers = self._headers.copy()
         chunk_start = self._num_bytes_downloaded + self._start_position
         chunk_end = chunk_start + self._chunksize - 1
-        if self._end_position < chunk_end:
-            chunk_end = self._end_position
+        chunk_end = min(self._end_position, chunk_end)
         headers["range"] = f"bytes={chunk_start}-{chunk_end}"
         resp, content = self._http.request(self._uri, "GET", headers=headers)
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

S3 and Azure can throw IncompleteReadError when the TCP session was disrupted. However, current implementation does not re-reaise it as MaybeRecoverableError. As a result, programs like pghoard will give up basebackup download.

This is more likely to affect large (2~4 TiB) databases, because large database takes longer to download base backup and more likely to encounter at least one IncompleteReadError.

This commit re-reaise IncompleteReadError as MaybeRecoverableError, so pghoard can retry on an object without starting over.

# Why this way

I learned that pghoard use `MaybeRecoverableError` to decide whether it will retry or not. So I thought re-reaise IncompleteReadError as MaybeRecoverableError might be an option.

