### PR TITLE
Add option to preserve trailing slash on deletes

### DIFF
--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -301,8 +301,10 @@ class AzureTransfer(BaseTransfer[Config]):
                     },
                 )
 
-    def delete_key(self, key: str) -> None:
-        path = self.format_key_for_backend(key, remove_slash_prefix=True)
+    def delete_key(self, key: str, preserve_trailing_slash: bool = False) -> None:
+        path = self.format_key_for_backend(
+            key, remove_slash_prefix=True, trailing_slash=preserve_trailing_slash and key.endswith("/")
+        )
         self.log.debug("Deleting key: %r", path)
         try:
             blob_client = self.get_blob_service_client().get_blob_client(container=self.container_name, blob=path)

--- a/rohmu/object_storage/base.py
+++ b/rohmu/object_storage/base.py
@@ -255,20 +255,20 @@ class BaseTransfer(Generic[StorageModelT]):
             raise StorageError(f"Key {repr(key)} does not start with expected prefix {repr(self.prefix)}")
         return key[len(self.prefix) :]
 
-    def delete_key(self, key: str) -> None:
+    def delete_key(self, key: str, preserve_trailing_slash: bool = False) -> None:
         raise NotImplementedError
 
-    def delete_keys(self, keys: Collection[str]) -> None:
+    def delete_keys(self, keys: Collection[str], preserve_trailing_slash: bool = False) -> None:
         """Delete specified keys"""
         for key in keys:
-            self.delete_key(key)
+            self.delete_key(key, preserve_trailing_slash=preserve_trailing_slash)
 
-    def delete_tree(self, key: str) -> None:
+    def delete_tree(self, key: str, preserve_trailing_slash: bool = False) -> None:
         """Delete all keys under given root key. Basic implementation works by just listing all available
         keys and deleting them individually but storage providers can implement more efficient logic."""
         self.log.debug("Deleting tree: %r", key)
         names = [item["name"] for item in self.list_path(key, with_metadata=False, deep=True)]
-        self.delete_keys(names)
+        self.delete_keys(names, preserve_trailing_slash=preserve_trailing_slash)
 
     def get_contents_to_file(
         self, key: str, filepath_to_store_to: AnyPath, *, progress_callback: ProgressProportionCallbackType = None

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -452,8 +452,8 @@ class GoogleTransfer(BaseTransfer[Config]):
                 else:
                     raise NotImplementedError(property_name)
 
-    def delete_key(self, key: str) -> None:
-        path = self.format_key_for_backend(key)
+    def delete_key(self, key: str, preserve_trailing_slash: bool = False) -> None:
+        path = self.format_key_for_backend(key, trailing_slash=preserve_trailing_slash and key.endswith("/"))
         self.log.debug("Deleting key: %r", path)
         with self._object_client(not_found=path) as clob:
             # https://googleapis.github.io/google-api-python-client/docs/dyn/storage_v1.objects.html#delete

--- a/rohmu/object_storage/sftp.py
+++ b/rohmu/object_storage/sftp.py
@@ -5,7 +5,7 @@
 
 from io import BytesIO
 from rohmu.common.statsd import StatsdConfig
-from rohmu.errors import FileNotFoundFromStorageError, InvalidConfigurationError
+from rohmu.errors import Error, FileNotFoundFromStorageError, InvalidConfigurationError
 from rohmu.notifier.interface import Notifier
 from rohmu.object_storage.base import (
     BaseTransfer,
@@ -210,7 +210,9 @@ class SFTPTransfer(BaseTransfer[Config]):
     ) -> None:
         raise NotImplementedError
 
-    def delete_key(self, key: str) -> None:
+    def delete_key(self, key: str, preserve_trailing_slash: bool = False) -> None:
+        if preserve_trailing_slash:
+            raise Error("SftpTransfer does not support preserving trailing slashes")
         target_path = self.format_key_for_backend(key.strip("/"))
         self.log.info("Removing path: %r", target_path)
 

--- a/rohmu/object_storage/swift.py
+++ b/rohmu/object_storage/swift.py
@@ -225,8 +225,8 @@ class SwiftTransfer(BaseTransfer[Config]):
                 with suppress(FileNotFoundFromStorageError):
                     self._delete_object_plain(item["name"])
 
-    def delete_key(self, key: str) -> None:
-        path = self.format_key_for_backend(key)
+    def delete_key(self, key: str, preserve_trailing_slash: bool = False) -> None:
+        path = self.format_key_for_backend(key, trailing_slash=preserve_trailing_slash and key.endswith("/"))
         self.log.debug("Deleting key: %r", path)
         try:
             headers = self.conn.head_object(self.container_name, path)

--- a/test/object_storage/test_sftp.py
+++ b/test/object_storage/test_sftp.py
@@ -1,10 +1,13 @@
 # Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/
 from datetime import datetime
 from io import BytesIO
+from rohmu.errors import Error
 from rohmu.object_storage.sftp import SFTPTransfer
 from tempfile import NamedTemporaryFile
-from typing import Any
-from unittest.mock import MagicMock, patch
+from typing import Any, Union
+from unittest.mock import call, MagicMock, patch
+
+import pytest
 
 
 def test_store_file_from_disk() -> None:
@@ -45,6 +48,80 @@ def test_store_file_from_disk() -> None:
 
 
 def test_store_file_object() -> None:
+    notifier = MagicMock()
+    with patch("paramiko.Transport") as _, patch("paramiko.SFTPClient") as sftp_client:
+        client = MagicMock()
+        sftp_client.from_transport.return_value = client
+        transfer = SFTPTransfer(
+            server="sftp.example.com",
+            port=2222,
+            username="testuser",
+            password="testpass",
+            notifier=notifier,
+        )
+        test_data = b"test-data"
+        file_object = BytesIO(test_data)
+
+        # Size reporting relies on the progress callback from paramiko
+        def upload_side_effect(*args: Any, **kwargs: Any) -> None:
+            if kwargs.get("callback"):
+                kwargs["callback"](len(test_data), len(test_data))
+
+        client.putfo = MagicMock(wraps=upload_side_effect)
+
+        metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
+        transfer.store_file_object(key="test_key2", fd=file_object, metadata=metadata)
+
+        client.putfo.assert_called()
+        notifier.object_created.assert_called_once_with(
+            key="test_key2", size=len(test_data), metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"}
+        )
+
+
+@pytest.mark.parametrize(
+    ("key", "preserve_trailing_slash", "expected_key"),
+    [
+        ("1", True, ""),
+        ("2/", True, ""),
+        ("1", False, "test-prefix/1"),
+        ("2/", False, "test-prefix/2"),
+        ("1", None, "test-prefix/1"),
+        ("2/", None, "test-prefix/2"),
+    ],
+)
+def test_delete_key(key: str, preserve_trailing_slash: Union[bool, None], expected_key: str) -> None:
+    notifier = MagicMock()
+    with patch("paramiko.Transport") as _, patch("paramiko.SFTPClient") as sftp_client:
+        client = MagicMock()
+        sftp_client.from_transport.return_value = client
+        transfer = SFTPTransfer(
+            server="sftp.example.com",
+            port=2222,
+            username="testuser",
+            password="testpass",
+            notifier=notifier,
+            prefix="test-prefix/",
+        )
+
+        if preserve_trailing_slash:
+            with pytest.raises(Error):
+                transfer.delete_key(key, preserve_trailing_slash=True)
+            client.remove.assert_not_called()
+        else:
+            if preserve_trailing_slash is None:
+                transfer.delete_key(key)
+            else:
+                transfer.delete_key(key, preserve_trailing_slash=preserve_trailing_slash)
+            client.assert_has_calls(
+                [
+                    call.remove(expected_key.strip("/") + ".metadata"),
+                    call.remove(expected_key.strip("/")),
+                ]
+            )
+
+
+@pytest.mark.parametrize("preserve_trailing_slash", [True, False, None])
+def test_delete_keys(preserve_trailing_slash: Union[bool, None]) -> None:
     notifier = MagicMock()
     with patch("paramiko.Transport") as _, patch("paramiko.SFTPClient") as sftp_client:
         client = MagicMock()


### PR DESCRIPTION
Most object storages support having a slash in the object
name and rohmu should be able to delete such objects.

Let the default behaviour the same but introduce an option
`preserve_trailing_slash` which allows to control whether the trailing
slash in the key are stripped or not.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #198 

# Why this way

Introducing a new flag is backward compatible and preserves the existing behaviour in case this is actually a requirement for some user.

We can later on switch the default value of `preserve_trailing_slash` to `True` if we think we want this behaviour by default.

For local/sftp which can't support slashes I opted for explicitly raising an `Error` if the user passes `preserve_trailing_slash=True` instead of just ignoring the parameter. 
