### PR TITLE
s3: upload parts from temporary file

### DIFF
--- a/rohmu/object_storage/config.py
+++ b/rohmu/object_storage/config.py
@@ -153,6 +153,7 @@ class S3ObjectStorageConfig(StorageModel):
     aws_session_token: Optional[str] = Field(None, repr=False)
     use_dualstack_endpoint: Optional[bool] = True
     storage_type: Literal[StorageDriver.s3] = StorageDriver.s3
+    temporary_directory: Optional[Path] = None
 
     @root_validator(skip_on_failure=True)
     @classmethod


### PR DESCRIPTION
Currently when doing many concurrent uploads, rohmu can use a lot of memory.  Copying parts first to a temporary file should not take a lot of extra time compared to uploading to s3.  Note that upload_part requires `.seek` so that retries work correctly, so we cannot just pass fp directly.