### PR TITLE
gcp: bulk request for gcp object storage deletion

### DIFF
--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from googleapiclient.discovery import build
-from googleapiclient.errors import HttpError
+from googleapiclient.errors import BatchError, HttpError
 from googleapiclient.http import (
+    BatchHttpRequest,
     build_http,
     HttpRequest,
     MediaDownloadProgress,
@@ -45,12 +46,13 @@ from rohmu.object_storage.config import (
     GoogleObjectStorageConfig as Config,
 )
 from rohmu.typing import AnyPath, Metadata
-from rohmu.util import get_total_size_from_content_range
+from rohmu.util import batched, get_total_size_from_content_range
 from typing import (
     Any,
     BinaryIO,
     Callable,
     cast,
+    Collection,
     Iterable,
     Iterator,
     Optional,
@@ -302,7 +304,9 @@ class GoogleTransfer(BaseTransfer[Config]):
             self.gs_bucket_client = self.gs.buckets()
         yield self.gs_bucket_client
 
-    def _retry_on_reset(self, request: HttpRequest, action: Callable[[], ResType], retry_reporter: Reporter) -> ResType:
+    def _retry_on_reset(
+        self, request: HttpRequest | BatchHttpRequest, action: Callable[[], ResType], retry_reporter: Reporter
+    ) -> ResType:
         retries = 60
         retry_wait = 2.0
         while True:
@@ -311,6 +315,7 @@ class GoogleTransfer(BaseTransfer[Config]):
             except (
                 IncompleteRead,
                 HttpError,
+                BatchError,
                 ssl.SSLEOFError,
                 socket.timeout,
                 OSError,
@@ -336,6 +341,9 @@ class GoogleTransfer(BaseTransfer[Config]):
                     raise
                 # getaddrinfo sometimes fails with "Name or service not known"
                 elif isinstance(ex, socket.gaierror) and ex.errno != socket.EAI_NONAME:
+                    raise
+                # batch request or response has a wrong format
+                elif isinstance(ex, BatchError):
                     raise
 
                 self.log.warning("%s failed: %s (%s), retrying in %.2fs", action, ex.__class__.__name__, ex, retry_wait)
@@ -472,6 +480,34 @@ class GoogleTransfer(BaseTransfer[Config]):
             self._retry_on_reset(req, req.execute, retry_reporter=reporter)
             reporter.report(self.stats)
             self.notifier.object_deleted(key)
+
+    def delete_keys(self, keys: Collection[str]) -> None:
+        self.log.debug("Deleting %i keys", len(keys))
+        reporter = Reporter(StorageOperation.delete_key)
+        with self._object_client() as object_resource:
+            for keys_batch in batched(keys, 1000):  # Cannot delete more than 1000 objects at a time
+                assert self.gs is not None
+                batch_request = self.gs.new_batch_http_request(callback=self._delete_keys_callback)
+                for key in keys_batch:
+                    path = self.format_key_for_backend(key)
+                    self.log.debug("Deleting key: %r", path)
+                    batch_request.add(object_resource.delete(bucket=self.bucket_name, object=path), request_id=key)
+
+                self._retry_on_reset(batch_request, batch_request.execute, retry_reporter=reporter)
+
+                for key in keys_batch:
+                    self.log.debug("Deleted key: %r", key)
+                    self.notifier.object_deleted(key)
+
+        reporter.report(self.stats)
+
+    def _delete_keys_callback(self, request_id: str, response: HttpRequest, exception: HttpError | None) -> None:
+        if exception is not None:
+            self.log.error(
+                "Received server error %r for request_id %s, Google API delete operation",
+                exception.resp["status"],
+                request_id,
+            )
 
     def get_contents_to_fileobj(
         self,

--- a/test/object_storage/test_google.py
+++ b/test/object_storage/test_google.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from contextlib import ExitStack
 from datetime import datetime, timezone
 from googleapiclient.errors import HttpError
-from googleapiclient.http import MediaUploadProgress
+from googleapiclient.http import HttpRequest, MediaUploadProgress
 from io import BytesIO
 from rohmu import InvalidConfigurationError
 from rohmu.common.models import StorageOperation
@@ -12,7 +12,7 @@ from rohmu.errors import InvalidByteRangeError, TransferObjectStoreMissingError,
 from rohmu.object_storage.base import IterKeyItem
 from rohmu.object_storage.google import GoogleTransfer, MediaIoBaseDownloadWithByteRange, Reporter
 from tempfile import NamedTemporaryFile
-from typing import Union
+from typing import Callable, Union
 from unittest.mock import ANY, call, MagicMock, Mock, patch
 
 import base64
@@ -195,41 +195,6 @@ def test_store_file_object() -> None:
         notifier.object_created.assert_called_once_with(
             key="test_key2", size=len(test_data), metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"}
         )
-
-
-@pytest.mark.parametrize(
-    ("total_keys,expected_bulk_request_count"),
-    (
-        (0, 0),
-        (1, 1),
-        (1000, 1),
-        (1001, 2),
-        (2000, 2),
-        (2001, 3),
-        (10_000, 10),
-    ),
-)
-def test_delete_keys(total_keys: int, expected_bulk_request_count: int) -> None:
-    notifier = MagicMock()
-    test_keys = _generate_keys(total_keys)
-    with ExitStack() as stack:
-        stack.enter_context(patch("rohmu.object_storage.google.get_credentials"))
-        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._create_object_store_if_needed_unwrapped"))
-        mock_retry_on_reset = stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._retry_on_reset"))
-        transfer = GoogleTransfer(
-            project_id="test-project-id",
-            bucket_name="test-bucket",
-            notifier=notifier,
-        )
-        mock_client = stack.enter_context(patch.object(transfer, "_object_client"))
-        mock_request = _mock_request([], resumable=None)
-        mock_client.return_value.__enter__.return_value.delete.return_value = mock_request
-
-        transfer.delete_keys(keys=test_keys)
-
-        assert notifier.object_deleted.call_count == total_keys
-        notifier.object_deleted.assert_has_calls([call(key) for key in test_keys])
-        assert mock_retry_on_reset.call_count == expected_bulk_request_count
 
 
 def _generate_keys(total: int, prefix: str = "test_key_") -> list[str]:
@@ -536,7 +501,7 @@ def test_delete_key(key: str, preserve_trailing_slash: Union[bool, None], expect
 
 
 @pytest.mark.parametrize("preserve_trailing_slash", [True, False, None])
-def test_delete_keys(preserve_trailing_slash: Union[bool, None]) -> None:
+def test_delete_keys_trailing_slash(preserve_trailing_slash: Union[bool, None]) -> None:
     notifier = MagicMock()
     with ExitStack() as stack:
         stack.enter_context(patch("rohmu.object_storage.google.get_credentials"))
@@ -558,14 +523,120 @@ def test_delete_keys(preserve_trailing_slash: Union[bool, None]) -> None:
 
         mock_client_delete = _init_google_client_mock.return_value.objects().delete
 
-        mock_client_delete = _init_google_client_mock.return_value.objects().delete
         expected_keys = ["2", "3", "4"] if not preserve_trailing_slash else ["2", "3", "4/"]
         expected_calls = []
         for key in expected_keys:
             expected_calls.extend(
                 [
                     call(bucket="test-bucket", object=f"test-prefix/{key}"),
-                    call().execute(),
                 ]
             )
         mock_client_delete.assert_has_calls(expected_calls)
+
+
+@pytest.mark.parametrize(
+    ("total_keys,expected_bulk_request_count"),
+    (
+        (0, 0),
+        (1, 1),
+        (100, 1),
+        (101, 2),
+        (200, 2),
+        (201, 3),
+        (1_000, 10),
+    ),
+)
+def test_delete_keys_bulk(total_keys: int, expected_bulk_request_count: int) -> None:
+    notifier = MagicMock()
+    test_keys = _generate_keys(total_keys)
+    with ExitStack() as stack:
+        stack.enter_context(patch("rohmu.object_storage.google.get_credentials"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._create_object_store_if_needed_unwrapped"))
+        mock_retry_on_reset = stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._retry_on_reset"))
+        transfer = GoogleTransfer(
+            project_id="test-project-id",
+            bucket_name="test-bucket",
+            notifier=notifier,
+        )
+        mock_client = stack.enter_context(patch.object(transfer, "_object_client"))
+        mock_request = _mock_request([], resumable=None)
+        mock_client.return_value.__enter__.return_value.delete.return_value = mock_request
+
+        transfer.delete_keys(keys=test_keys)
+
+        assert mock_retry_on_reset.call_count == expected_bulk_request_count
+
+
+class BatchRequestProcessor:
+    def __init__(self, callback: Callable[[str, HttpRequest | None, HttpError | None], None]) -> None:
+        self.callback = callback
+        self.operations: list[str] = []
+
+    def execute(self) -> None:
+        for key in self.operations:
+            if "500" in key:
+                self.callback(key, None, HttpError(resp=httplib2.Response({"status": "500"}), content=b"500"))
+                return
+            if "404" in key:
+                self.callback(key, None, HttpError(resp=httplib2.Response({"status": "404"}), content=b"404"))
+                return
+            self.callback(key, None, None)
+
+    def add(self, operation: HttpRequest, request_id: str) -> None:
+        self.operations.append(request_id)
+
+
+def test_delete_keys_callback() -> None:
+    notifier = MagicMock()
+    with ExitStack() as stack:
+        stack.enter_context(patch("rohmu.object_storage.google.get_credentials"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._create_object_store_if_needed_unwrapped"))
+        mock_delete_key = stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer.delete_key"))
+
+        transfer = GoogleTransfer(
+            project_id="test-project-id",
+            bucket_name="test-bucket",
+            notifier=notifier,
+        )
+
+        mock_batch_request = MagicMock()
+        mock_batch_request.execute.return_value = None
+
+        test_keys = ["key1", "key2", "key3_500"]
+
+        mock_gs = MagicMock()
+        mock_gs.new_batch_http_request = lambda callback: BatchRequestProcessor(callback)
+        transfer.gs = mock_gs
+
+        transfer.delete_keys(keys=test_keys)
+
+        notifier.object_deleted.assert_has_calls([call("key1"), call("key2")])
+        mock_delete_key.assert_called_once_with("key3_500", preserve_trailing_slash=False)
+
+
+def test_delete_keys_callback_failure() -> None:
+    notifier = MagicMock()
+    with ExitStack() as stack:
+        stack.enter_context(patch("rohmu.object_storage.google.get_credentials"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._create_object_store_if_needed_unwrapped"))
+        mock_delete_key = stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer.delete_key"))
+
+        transfer = GoogleTransfer(
+            project_id="test-project-id",
+            bucket_name="test-bucket",
+            notifier=notifier,
+        )
+
+        test_keys = ["key1", "key2", "key3_404"]
+
+        mock_gs = MagicMock()
+        mock_gs.new_batch_http_request = lambda callback: BatchRequestProcessor(callback)
+        transfer.gs = mock_gs
+
+        with pytest.raises(HttpError) as exc_info:
+            transfer.delete_keys(keys=test_keys)
+
+        assert exc_info.value.resp["status"] == "404"
+
+        notifier.object_deleted.assert_has_calls([call("key1"), call("key2")])
+        mock_delete_key.assert_not_called()

--- a/test/object_storage/test_google.py
+++ b/test/object_storage/test_google.py
@@ -197,6 +197,45 @@ def test_store_file_object() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("total_keys,expected_bulk_request_count"),
+    (
+        (0, 0),
+        (1, 1),
+        (1000, 1),
+        (1001, 2),
+        (2000, 2),
+        (2001, 3),
+        (10_000, 10),
+    ),
+)
+def test_delete_keys(total_keys: int, expected_bulk_request_count: int) -> None:
+    notifier = MagicMock()
+    test_keys = _generate_keys(total_keys)
+    with ExitStack() as stack:
+        stack.enter_context(patch("rohmu.object_storage.google.get_credentials"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._create_object_store_if_needed_unwrapped"))
+        mock_retry_on_reset = stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._retry_on_reset"))
+        transfer = GoogleTransfer(
+            project_id="test-project-id",
+            bucket_name="test-bucket",
+            notifier=notifier,
+        )
+        mock_client = stack.enter_context(patch.object(transfer, "_object_client"))
+        mock_request = _mock_request([], resumable=None)
+        mock_client.return_value.__enter__.return_value.delete.return_value = mock_request
+
+        transfer.delete_keys(keys=test_keys)
+
+        assert notifier.object_deleted.call_count == total_keys
+        notifier.object_deleted.assert_has_calls([call(key) for key in test_keys])
+        assert mock_retry_on_reset.call_count == expected_bulk_request_count
+
+
+def _generate_keys(total: int, prefix: str = "test_key_") -> list[str]:
+    return [f"{prefix}{i+1}" for i in range(total)]
+
+
 def test_upload_size_unknown_to_reporter() -> None:
     notifier = MagicMock()
     with ExitStack() as stack:
@@ -254,7 +293,7 @@ def test_get_contents_to_fileobj_raises_error_on_invalid_byte_range() -> None:
             )
 
 
-def _mock_request(calls: list[tuple[str, bytes]]) -> Mock:
+def _mock_request(calls: list[tuple[str, bytes]], resumable: bool | None = None) -> Mock:
     results = []
     for call_content_range, call_content in calls:
         response = Mock()
@@ -269,6 +308,7 @@ def _mock_request(calls: list[tuple[str, bytes]]) -> Mock:
     request = Mock()
     request.headers = {}
     request.http.request = http_call
+    request.resumable = resumable
     return request
 
 


### PR DESCRIPTION
Batch multiple delete google API calls in a single HTTP request.
A single batch request is limited to 100 calls (recommended max batch size)
When we request more calls that that, we execute multiple batch requests.

Error handling

Any unsuccessful sub-request is retried before escalation (if status code is related to temporal errors).


[DDB-1246]