### PR TITLE
s3: optionally convert metadata keys to lowercase

### DIFF
--- a/rohmu/object_storage/config.py
+++ b/rohmu/object_storage/config.py
@@ -170,6 +170,11 @@ class S3ObjectStorageConfig(StorageModel):
     storage_type: Literal[StorageDriver.s3] = StorageDriver.s3
     min_multipart_chunk_size: Optional[int] = None
     user_agent_extra: Optional[str] = None
+    # Some S3-compatible providers return object metadata keys in
+    # Title-Case. But AWS lowercases user defined metadata keys
+    # ref: https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html)
+    # Enable this to normalize (lower case) keys on read so callers can look up lowercased keys.
+    lowercase_metadata_keys: bool = False
 
     @root_validator(skip_on_failure=True)
     @classmethod

--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -138,6 +138,7 @@ class S3Transfer(BaseTransfer[Config]):
         ensure_object_store_available: bool = True,
         min_multipart_chunk_size: Optional[int] = None,
         user_agent_extra: Optional[str] = None,
+        lowercase_metadata_keys: bool = False,
     ) -> None:
         super().__init__(
             prefix=prefix,
@@ -163,6 +164,7 @@ class S3Transfer(BaseTransfer[Config]):
         self.default_multipart_chunk_size = max(segment_size, min_multipart_chunk_size or 0)
         self.encrypted = encrypted
         self.user_agent_extra = user_agent_extra
+        self.lowercase_metadata_keys = lowercase_metadata_keys
         self.s3_client: Optional[S3Client] = None
         self.location = ""
         if not self.host or not self.port:
@@ -179,6 +181,11 @@ class S3Transfer(BaseTransfer[Config]):
 
     def _verify_object_storage_unwrapped(self) -> None:
         self.check_or_create_bucket(create_if_needed=False)
+
+    def _normalize_metadata_keys(self, metadata: Metadata) -> Metadata:
+        if self.lowercase_metadata_keys:
+            return {k.lower(): v for k, v in metadata.items()}
+        return metadata
 
     def calculate_max_unknown_file_size(self) -> int:
         return self.default_multipart_chunk_size * S3_MAX_NUM_PARTS_PER_UPLOAD
@@ -340,7 +347,7 @@ class S3Transfer(BaseTransfer[Config]):
             else:
                 raise StorageError(f"Metadata lookup failed for {key}") from ex
 
-        return response["Metadata"]
+        return self._normalize_metadata_keys(response["Metadata"])
 
     def delete_key(self, key: str, preserve_trailing_slash: bool = False) -> None:
         path = self.format_key_for_backend(
@@ -437,7 +444,8 @@ class S3Transfer(BaseTransfer[Config]):
                 raise FileNotFoundFromStorageError(path)
             else:
                 raise StorageError(f"Fetching the remote object {path} failed") from ex
-        return response["Body"], response["ContentLength"], response["Metadata"]
+        metadata = self._normalize_metadata_keys(response["Metadata"])
+        return response["Body"], response["ContentLength"], metadata
 
     def _read_object_to_fileobj(
         self, fileobj: BinaryIO, streaming_body: StreamingBody, body_length: int, cb: ProgressProportionCallbackType = None

--- a/test/object_storage/test_s3.py
+++ b/test/object_storage/test_s3.py
@@ -767,3 +767,54 @@ def test_multipart_upload_source_file_empty(mocker: Any, tmp_path: Path) -> None
                 progress_fn=progress_fn,
                 size=size,
             )
+
+
+@pytest.mark.parametrize("lowercase_metadata_keys", [False, True])
+def test_get_metadata_for_key_case(mocker: Any, lowercase_metadata_keys: bool) -> None:
+    transfer = make_mock_transfer(
+        mocker,
+        {
+            "region": "test-region",
+            "bucket_name": "test-bucket",
+            "prefix": "test-prefix",
+            "lowercase_metadata_keys": lowercase_metadata_keys,
+        },
+    )
+    s3_client = transfer.get_client()
+    assert isinstance(s3_client, MagicMock)
+    s3_client.head_object.return_value = {
+        "Metadata": {"Compression-Algorithm": "lzma", "Encryption-Key-Id": "k1"},
+    }
+    metadata = transfer.get_metadata_for_key("test_key")
+    if lowercase_metadata_keys:
+        assert metadata == {"compression-algorithm": "lzma", "encryption-key-id": "k1"}
+    else:
+        assert metadata == {"Compression-Algorithm": "lzma", "Encryption-Key-Id": "k1"}
+
+
+@pytest.mark.parametrize("lowercase_metadata_keys", [False, True])
+def test_get_contents_to_fileobj_metadata_case(mocker: Any, lowercase_metadata_keys: bool) -> None:
+    transfer = make_mock_transfer(
+        mocker,
+        {
+            "region": "test-region",
+            "bucket_name": "test-bucket",
+            "prefix": "test-prefix",
+            "lowercase_metadata_keys": lowercase_metadata_keys,
+        },
+    )
+    body = MagicMock()
+    body.read.side_effect = [b"data", b""]
+    s3_client = transfer.get_client()
+    assert isinstance(s3_client, MagicMock)
+    s3_client.get_object.return_value = {
+        "Body": body,
+        "ContentLength": 4,
+        "Metadata": {"Compression-Algorithm": "lzma"},
+    }
+    buf = BytesIO()
+    metadata = transfer.get_contents_to_fileobj("test_key", buf)
+    if lowercase_metadata_keys:
+        assert metadata == {"compression-algorithm": "lzma"}
+    else:
+        assert metadata == {"Compression-Algorithm": "lzma"}


### PR DESCRIPTION
some s3-compatible providers, actually do not convert user defined metadata keys to lowercase (as [AWS S3 does](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html)), which can break the users of rohmu expecting metadata keys for s3-compatible storage to be in lowercase.

note that when iterating keys rohmu already forces metadata keys to be in lowercase [here](https://github.com/Aiven-Open/rohmu/blob/d16d04caa878220b9811ac415a29f20fdbd264ef/rohmu/object_storage/s3.py#L396), but here just to avoid any unintentional side effects and to be backward compatible we're adding a new option to control this behavior in other two main places as well.
