### PR TITLE
object_storage: add support for regional storage endpoints [PGSQL-1190]

### DIFF
--- a/rohmu/object_storage/config.py
+++ b/rohmu/object_storage/config.py
@@ -12,6 +12,7 @@ from rohmu.common.models import ProxyInfo, StorageDriver, StorageModel
 from typing import Any, Dict, Final, Literal, Optional, TypeVar
 
 import platform
+import re
 
 StorageModelT = TypeVar("StorageModelT", bound=StorageModel)
 
@@ -58,6 +59,8 @@ AZURE_MAX_NUM_PARTS_PER_UPLOAD: Final[int] = 10000
 GOOGLE_DOWNLOAD_CHUNK_SIZE: Final[int] = 1024 * 1024 * 5 if (get_total_memory() or 0) < 2048 else 1024 * 1024 * 50
 GOOGLE_UPLOAD_CHUNK_SIZE: Final[int] = 1024 * 1024 * 5
 GOOGLE_MAX_NUM_PARTS_PER_UPLOAD: Final[int] = 10000
+# GCS region/location names as used in regional endpoint hostnames, e.g. "us-west4", "europe-west1", "nam4".
+GOOGLE_DIRECT_LOCATION_PATTERN: Final[str] = r"^[a-z0-9]+(-[a-z0-9]+)*$"
 
 LOCAL_CHUNK_SIZE: Final[int] = 1024 * 1024
 
@@ -123,6 +126,7 @@ class GoogleObjectStorageConfig(StorageModel):
     credential_file: Optional[Path] = None
     credentials: Optional[Dict[str, Any]] = Field(None, repr=False)
     proxy_info: Optional[ProxyInfo] = None
+    direct_location: Optional[str] = None
     prefix: Optional[str] = None
     storage_type: Literal[StorageDriver.google] = StorageDriver.google
 
@@ -132,6 +136,18 @@ class GoogleObjectStorageConfig(StorageModel):
         if values["project_id"] is None and values["bucket_name"] is None:
             raise ValueError("at least one of project_id, bucket_name must be set")
         return values
+
+    @validator("direct_location")
+    @classmethod
+    def valid_direct_location(cls, v: Optional[str]) -> Optional[str]:
+        # None means "use the global endpoint". Anything else is interpolated into a hostname,
+        # so reject malformed values here; "" would otherwise yield
+        # https://storage..rep.googleapis.com/storage/v1/
+        if v is None:
+            return v
+        if not re.fullmatch(GOOGLE_DIRECT_LOCATION_PATTERN, v):
+            raise ValueError(f"invalid direct_location: {v!r}, must match {GOOGLE_DIRECT_LOCATION_PATTERN}")
+        return v
 
 
 class LocalObjectStorageConfig(StorageModel):

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -224,6 +224,7 @@ class GoogleTransfer(BaseTransfer[Config]):
         notifier: Optional[Notifier] = None,
         statsd_info: Optional[StatsdConfig] = None,
         ensure_object_store_available: bool = True,
+        direct_location: Optional[str] = None,
     ) -> None:
         super().__init__(
             prefix=prefix,
@@ -233,6 +234,16 @@ class GoogleTransfer(BaseTransfer[Config]):
         )
         self.project_id = project_id
         self.proxy_info = proxy_info
+
+        # default is using the global storage endpoint https://storage.googleapis.com/storage/v1/, but we can override it
+        # with the regional endpoint https://storage.{direct_location}.rep.googleapis.com/storage/v1/ here.
+        # see https://docs.cloud.google.com/storage/docs/regional-endpoints
+        self.regional_endpoint: str | None
+        if direct_location is not None:
+            self.regional_endpoint = f"https://storage.{direct_location}.rep.googleapis.com/storage/v1/"
+        else:
+            self.regional_endpoint = None
+
         self.google_creds = get_credentials(credential_file=credential_file, credentials=credentials)
         self.gs: Optional[StorageResource] = self._init_google_client()
         self.gs_object_client: Optional[StorageResource.ObjectsResource] = None
@@ -275,9 +286,12 @@ class GoogleTransfer(BaseTransfer[Config]):
             authorized_http = google_auth_httplib2.AuthorizedHttp(self.google_creds, http=http)
 
             try:
+                kwargs = {"http": authorized_http}
+                if self.regional_endpoint is not None:
+                    kwargs["client_options"] = {"api_endpoint": self.regional_endpoint}
                 # sometimes fails: httplib2.ServerNotFoundError: Unable to find the server at www.googleapis.com
                 # https://googleapis.github.io/google-api-python-client/docs/dyn/storage_v1.html
-                return build("storage", "v1", http=authorized_http)
+                return build("storage", "v1", **kwargs)
             except (httplib2.ServerNotFoundError, socket.timeout):
                 if time.monotonic() - start_time > 600:
                     raise

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -40,6 +40,7 @@ from rohmu.object_storage.base import (
     ProgressProportionCallbackType,
 )
 from rohmu.object_storage.config import (
+    GOOGLE_DIRECT_LOCATION_PATTERN as DIRECT_LOCATION_PATTERN,
     GOOGLE_DOWNLOAD_CHUNK_SIZE as DOWNLOAD_CHUNK_SIZE,
     GOOGLE_MAX_NUM_PARTS_PER_UPLOAD as MAX_NUM_PARTS_PER_UPLOAD,
     GOOGLE_UPLOAD_CHUNK_SIZE as UPLOAD_CHUNK_SIZE,
@@ -81,6 +82,7 @@ import json
 import logging
 import os
 import random
+import re
 import socket
 import ssl
 import time
@@ -240,6 +242,8 @@ class GoogleTransfer(BaseTransfer[Config]):
         # see https://docs.cloud.google.com/storage/docs/regional-endpoints
         self.regional_endpoint: str | None
         if direct_location is not None:
+            if not re.fullmatch(DIRECT_LOCATION_PATTERN, direct_location):
+                raise InvalidConfigurationError(f"Invalid direct location {repr(direct_location)}")
             self.regional_endpoint = f"https://storage.{direct_location}.rep.googleapis.com/storage/v1/"
         else:
             self.regional_endpoint = None
@@ -286,12 +290,10 @@ class GoogleTransfer(BaseTransfer[Config]):
             authorized_http = google_auth_httplib2.AuthorizedHttp(self.google_creds, http=http)
 
             try:
-                kwargs = {"http": authorized_http}
-                if self.regional_endpoint is not None:
-                    kwargs["client_options"] = {"api_endpoint": self.regional_endpoint}
+                client_options = {"api_endpoint": self.regional_endpoint} if self.regional_endpoint else None
                 # sometimes fails: httplib2.ServerNotFoundError: Unable to find the server at www.googleapis.com
                 # https://googleapis.github.io/google-api-python-client/docs/dyn/storage_v1.html
-                return build("storage", "v1", **kwargs)
+                return build("storage", "v1", http=authorized_http, client_options=client_options)
             except (httplib2.ServerNotFoundError, socket.timeout):
                 if time.monotonic() - start_time > 600:
                     raise

--- a/test/object_storage/test_google.py
+++ b/test/object_storage/test_google.py
@@ -6,10 +6,13 @@ from datetime import datetime, timezone
 from googleapiclient.errors import HttpError
 from googleapiclient.http import HttpRequest, MediaUploadProgress
 from io import BytesIO
+from pydantic.v1 import ValidationError
 from rohmu import InvalidConfigurationError
 from rohmu.common.models import StorageOperation
 from rohmu.errors import InvalidByteRangeError, TransferObjectStoreMissingError, TransferObjectStorePermissionError
+from rohmu.factory import get_transfer_model
 from rohmu.object_storage.base import IterKeyItem
+from rohmu.object_storage.config import GoogleObjectStorageConfig
 from rohmu.object_storage.google import GoogleTransfer, MediaIoBaseDownloadWithByteRange, Reporter
 from tempfile import NamedTemporaryFile
 from typing import Callable, Union
@@ -701,9 +704,13 @@ def test_project_id_required_for_ensuring_object_store() -> None:
         ("us-west4", "https://storage.us-west4.rep.googleapis.com/storage/v1/"),
     ),
 )
-def test_region_endpoint(direct_location: str | None, expected_endpoint: str | None) -> None:
+def test_region_endpoint(direct_location: str | None, expected_endpoint: str) -> None:
     """Test that we can create a transfer with a custom region endpoint."""
     with ExitStack() as stack:
+        # the credentials need a real universe domain, otherwise googleapiclient refuses to build any request
+        stack.enter_context(
+            patch("rohmu.object_storage.google.get_credentials", return_value=MagicMock(universe_domain="googleapis.com"))
+        )
         stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._verify_object_storage_unwrapped"))
         transfer = GoogleTransfer(
             project_id="test-project-id",
@@ -716,4 +723,82 @@ def test_region_endpoint(direct_location: str | None, expected_endpoint: str | N
         else:
             assert transfer.regional_endpoint == expected_endpoint
         assert transfer.gs is not None
-        assert transfer.gs._baseUrl == expected_endpoint  # type: ignore[attr-defined]
+        request = transfer.gs.objects().get(bucket="test-bucket", object="test-key")
+        assert request.uri.startswith(expected_endpoint)
+
+
+@pytest.mark.parametrize("direct_location", (None, "us-west4", "europe-west1", "us1"))
+def test_direct_location_accepted(direct_location: str | None) -> None:
+    """A region name made of lowercase alphanumeric dash-separated parts is accepted, as is no region at all."""
+    with ExitStack() as stack:
+        stack.enter_context(patch("rohmu.object_storage.google.get_credentials"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._init_google_client"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._verify_object_storage_unwrapped"))
+        transfer = GoogleTransfer(
+            project_id="test-project-id",
+            bucket_name="test-bucket",
+            notifier=MagicMock(),
+            direct_location=direct_location,
+        )
+        if direct_location is None:
+            assert transfer.regional_endpoint is None
+        else:
+            assert transfer.regional_endpoint == f"https://storage.{direct_location}.rep.googleapis.com/storage/v1/"
+
+
+@pytest.mark.parametrize("direct_location", ("", "US_West4", "not_a_region", "-us-west4", "us-west4-", "us-west4\n"))
+def test_direct_location_rejected(direct_location: str) -> None:
+    """Anything that is not a lowercase dash-separated region name is rejected before the client is built."""
+    with ExitStack() as stack:
+        stack.enter_context(patch("rohmu.object_storage.google.get_credentials"))
+        init_google_client = stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._init_google_client"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._verify_object_storage_unwrapped"))
+        with pytest.raises(InvalidConfigurationError):
+            GoogleTransfer(
+                project_id="test-project-id",
+                bucket_name="test-bucket",
+                notifier=MagicMock(),
+                direct_location=direct_location,
+            )
+        init_google_client.assert_not_called()
+
+
+def test_direct_location_from_config_dict() -> None:
+    """A direct_location in a storage config dict must reach the transfer instead of being dropped.
+
+    StorageModel does not actually forbid extra keys, so before direct_location was modelled it was
+    silently discarded rather than rejected. Assert on the dict that BaseTransfer.from_model splats
+    into __init__, since that is where the key went missing.
+    """
+    model = get_transfer_model(
+        {
+            "storage_type": "google",
+            "project_id": "test-project-id",
+            "bucket_name": "test-bucket",
+            "direct_location": "us-west4",
+        }
+    )
+    assert isinstance(model, GoogleObjectStorageConfig)
+    assert model.direct_location == "us-west4"
+    assert model.dict(by_alias=True, exclude={"storage_type"})["direct_location"] == "us-west4"
+
+    with ExitStack() as stack:
+        stack.enter_context(patch("rohmu.object_storage.google.get_credentials"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._init_google_client"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._verify_object_storage_unwrapped"))
+        transfer = GoogleTransfer.from_model(model, MagicMock())
+        assert transfer.regional_endpoint == "https://storage.us-west4.rep.googleapis.com/storage/v1/"
+
+
+@pytest.mark.parametrize("direct_location", ("", "US_West4", "not_a_region", "us-west4\n"))
+def test_direct_location_rejected_by_config(direct_location: str) -> None:
+    """The config layer rejects a malformed direct_location with pydantic's error, not InvalidConfigurationError."""
+    with pytest.raises(ValidationError):
+        get_transfer_model(
+            {
+                "storage_type": "google",
+                "project_id": "test-project-id",
+                "bucket_name": "test-bucket",
+                "direct_location": direct_location,
+            }
+        )

--- a/test/object_storage/test_google.py
+++ b/test/object_storage/test_google.py
@@ -692,3 +692,28 @@ def test_project_id_required_for_ensuring_object_store() -> None:
             notifier=notifier,
             ensure_object_store_available=True,
         )
+
+
+@pytest.mark.parametrize(
+    ("direct_location", "expected_endpoint"),
+    (
+        (None, "https://storage.googleapis.com/storage/v1/"),
+        ("us-west4", "https://storage.us-west4.rep.googleapis.com/storage/v1/"),
+    ),
+)
+def test_region_endpoint(direct_location: str | None, expected_endpoint: str | None) -> None:
+    """Test that we can create a transfer with a custom region endpoint."""
+    with ExitStack() as stack:
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._verify_object_storage_unwrapped"))
+        transfer = GoogleTransfer(
+            project_id="test-project-id",
+            bucket_name="test-bucket",
+            notifier=MagicMock(),
+            direct_location=direct_location,
+        )
+        if direct_location is None:
+            assert transfer.regional_endpoint is None
+        else:
+            assert transfer.regional_endpoint == expected_endpoint
+        assert transfer.gs is not None
+        assert transfer.gs._baseUrl == expected_endpoint  # type: ignore[attr-defined]


### PR DESCRIPTION

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

Instead of using the global storage endpoint https://storage.googleapis.com/storage/v1/ passing `direct_location=REGION_OR_MULTI_REGION` allows to use the regional endpoint instead.

See https://docs.cloud.google.com/storage/docs/request-endpoints and https://docs.cloud.google.com/storage/docs/regional-endpoints.