### PR TITLE
skip JSON batch API for GCS regional storage endpoints

### DIFF
--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -518,6 +518,15 @@ class GoogleTransfer(BaseTransfer[Config]):
             self.notifier.object_deleted(key)
 
     def delete_keys(self, keys: Iterable[str], preserve_trailing_slash: bool = False) -> None:
+        if self.regional_endpoint is not None:
+            # Regional endpoints don't support the JSON API batch endpoint
+            # (https://docs.cloud.google.com/storage/docs/regional-endpoints#json-api-batch), so fall back to
+            # deleting keys one by one instead of batching the requests.
+            self.log.debug("Deleting keys one by one, regional endpoint does not support batching")
+            for key in keys:
+                self.delete_key(key, preserve_trailing_slash=preserve_trailing_slash)
+            return
+
         retry_deletion_keys: list[str] = []
 
         def _delete_keys_callback(key: str, response: HttpRequest, exception: HttpError | None) -> None:

--- a/test/object_storage/test_google.py
+++ b/test/object_storage/test_google.py
@@ -581,6 +581,34 @@ def test_delete_keys_bulk(total_keys: int, expected_bulk_request_count: int) -> 
         assert mock_retry_on_reset.call_count == expected_bulk_request_count
 
 
+@pytest.mark.parametrize("total_keys", (0, 1, 2, 101))
+def test_delete_keys_regional_endpoint_skips_batching(total_keys: int) -> None:
+    """Regional endpoints don't support the JSON API batch endpoint, so delete_keys must fall back
+    to deleting keys one by one instead of using new_batch_http_request()."""
+    notifier = MagicMock()
+    test_keys = _generate_keys(total_keys)
+    with ExitStack() as stack:
+        stack.enter_context(patch("rohmu.object_storage.google.get_credentials"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._create_object_store_if_needed_unwrapped"))
+        mock_init_client = stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._init_google_client"))
+        mock_retry_on_reset = stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._retry_on_reset"))
+        transfer = GoogleTransfer(
+            project_id="test-project-id",
+            bucket_name="test-bucket",
+            notifier=notifier,
+            direct_location="us-west4",
+        )
+        mock_client = stack.enter_context(patch.object(transfer, "_object_client"))
+        mock_request = _mock_request([], resumable=None)
+        mock_client.return_value.__enter__.return_value.delete.return_value = mock_request
+
+        transfer.delete_keys(keys=test_keys)
+
+        # one delete_key call (and thus one _retry_on_reset call) per key, no batching
+        assert mock_retry_on_reset.call_count == total_keys
+        mock_init_client.return_value.new_batch_http_request.assert_not_called()
+
+
 class BatchRequestProcessor:
     def __init__(self, callback: Callable[[str, HttpRequest | None, HttpError | None], None]) -> None:
         self.callback = callback


### PR DESCRIPTION
Regional storage endpoints for Google Cloud Storage do not support the JSON API batch endpoint, so delete_keys() now falls back to deleting keys one by one when a regional endpoint is configured, instead of grouping delete requests into batch HTTP requests.

