### PR TITLE
compressor: bound DecompressSink output chunk size per algorithm [PGSQL-1193]

### DIFF
--- a/rohmu/compressor.py
+++ b/rohmu/compressor.py
@@ -5,10 +5,11 @@
 from .errors import InvalidConfigurationError
 from .filewrap import Sink, Stream
 from .snappyfile import SnappyFile
-from .typing import BinaryData, Compressor, Decompressor, FileLike, HasRead, HasWrite
+from .typing import BinaryData, Compressor, FileLike, HasRead, HasWrite, SinkDecompressor
 from .zstdfile import open as zstd_open
 from typing import cast, IO
 
+import io
 import lzma
 
 try:
@@ -20,6 +21,10 @@ try:
     import zstandard as zstd
 except ImportError:
     zstd = None  # type: ignore
+
+
+OUTPUT_CHUNK_SIZE = 128 * 1024
+SNAPPY_INPUT_SLICE_SIZE = 256 * 1024
 
 
 def CompressionFile(dst_fp: FileLike, algorithm: str, level: int = 0, threads: int = 0) -> FileLike:
@@ -78,25 +83,99 @@ def DecompressionFile(src_fp: FileLike, algorithm: str) -> FileLike:
     return src_fp
 
 
-class DecompressSink(Sink):
-    def __init__(self, next_sink: HasWrite, compression_algorithm: str):
-        super().__init__(next_sink)
-        self.decompressor = self._create_decompressor(compression_algorithm)
+class SnappySinkDecompressor:
+    def __init__(self, next_sink: HasWrite) -> None:
+        self._sink = Sink(next_sink)
+        self._decompressor = snappy.StreamDecompressor()
 
-    def _create_decompressor(self, alg: str) -> Decompressor:
+    def decompress(self, data: memoryview) -> None:
+        for offset in range(0, len(data), SNAPPY_INPUT_SLICE_SIZE):
+            output = self._decompressor.decompress(bytes(data[offset : offset + SNAPPY_INPUT_SLICE_SIZE]))
+            if output:
+                self._sink.write(output)
+
+
+class LzmaSinkDecompressor:
+    def __init__(self, next_sink: HasWrite) -> None:
+        self._sink = Sink(next_sink)
+        self._decompressor = lzma.LZMADecompressor()
+
+    def decompress(self, data: memoryview) -> None:
+        output = self._decompressor.decompress(
+            data,
+            max_length=OUTPUT_CHUNK_SIZE,
+        )
+
+        # Drain buffered output until the decoder needs more input
+        # or reaches EOF.
+        while True:
+            if output:
+                self._sink.write(output)
+
+            if self._decompressor.needs_input or self._decompressor.eof:
+                return
+
+            output = self._decompressor.decompress(
+                b"",
+                max_length=OUTPUT_CHUNK_SIZE,
+            )
+
+
+class ZstdOutputSink(io.RawIOBase):
+    def __init__(self, next_sink: HasWrite) -> None:
+        super().__init__()
+        self._sink = Sink(next_sink)
+
+    def write(self, data: BinaryData) -> int:  # type: ignore[override]
+        return self._sink.write(data)
+
+    def writable(self) -> bool:
+        return True
+
+
+class ZstdSinkDecompressor:
+    def __init__(self, next_sink: HasWrite) -> None:
+        self._output_sink = ZstdOutputSink(next_sink)
+
+        self._decompression_writer = zstd.ZstdDecompressor().stream_writer(
+            cast(IO[bytes], self._output_sink),
+            closefd=False,
+            write_size=OUTPUT_CHUNK_SIZE,
+        )
+
+    def decompress(self, data: memoryview) -> None:
+        self._decompression_writer.write(data)
+
+
+class DecompressSink(Sink):
+    def __init__(
+        self,
+        next_sink: HasWrite,
+        compression_algorithm: str,
+    ) -> None:
+        super().__init__(next_sink)
+
+        self.decompressor: SinkDecompressor = self._create_decompressor(compression_algorithm)
+
+    def _create_decompressor(
+        self,
+        alg: str,
+    ) -> SinkDecompressor:
         if alg == "snappy":
-            return snappy.StreamDecompressor()
-        elif alg == "lzma":
-            return lzma.LZMADecompressor()
-        elif alg == "zstd":
-            return zstd.ZstdDecompressor().decompressobj()
-        raise InvalidConfigurationError(f"invalid compression algorithm: {repr(alg)}")
+            return SnappySinkDecompressor(self.next_sink)
+
+        if alg == "lzma":
+            return LzmaSinkDecompressor(self.next_sink)
+
+        if alg == "zstd":
+            return ZstdSinkDecompressor(self.next_sink)
+
+        raise InvalidConfigurationError(f"invalid compression algorithm: {alg!r}")
 
     def write(self, data: BinaryData) -> int:
-        data = bytes(data) if not isinstance(data, bytes) else data
-        written = len(data)
-        if not data:
-            return written
-        data = self.decompressor.decompress(data)
-        self._write_to_next_sink(data)
-        return written
+        view = memoryview(data)
+
+        if view:
+            self.decompressor.decompress(view)
+
+        return len(view)

--- a/rohmu/typing.py
+++ b/rohmu/typing.py
@@ -83,3 +83,7 @@ class Compressor(Protocol):
 
 class Decompressor(Protocol):
     def decompress(self, data: bytes) -> bytes: ...
+
+
+class SinkDecompressor(Protocol):
+    def decompress(self, data: memoryview) -> None: ...

--- a/test/test_decompress_sink.py
+++ b/test/test_decompress_sink.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from rohmu.compressor import (
+    CompressionFile,
+    DecompressSink,
+    OUTPUT_CHUNK_SIZE,
+    SNAPPY_INPUT_SLICE_SIZE,
+)
+from rohmu.encryptor import SymmetricDecryptSink, SymmetricEncryptor
+from rohmu.typing import BinaryData
+from typing import Iterable
+
+import hashlib
+import io
+import itertools
+import pytest
+import random
+
+
+class MeasuringSink:
+    def __init__(self) -> None:
+        self.digest = hashlib.sha256()
+        self.max_write_size = 0
+        self.total_written = 0
+        self.write_count = 0
+
+    def write(self, data: BinaryData) -> int:
+        view = memoryview(data)
+        self.digest.update(view)
+        self.max_write_size = max(self.max_write_size, len(view))
+        self.total_written += len(view)
+        self.write_count += 1
+        return len(view)
+
+
+class ShortWriteSink(MeasuringSink):
+    def __init__(self, limit: int) -> None:
+        super().__init__()
+        self.limit = limit
+
+    def write(self, data: BinaryData) -> int:
+        view = memoryview(data)
+        accepted = min(len(view), self.limit)
+        accepted_data = view[:accepted]
+        self.digest.update(accepted_data)
+        self.max_write_size = max(self.max_write_size, accepted)
+        self.total_written += accepted
+        self.write_count += 1
+        return accepted
+
+
+def compress(algorithm: str, data: bytes) -> bytes:
+    target = io.BytesIO()
+    compressor = CompressionFile(target, algorithm)
+    compressor.write(data)
+    compressor.close()
+    return target.getvalue()
+
+
+def boundaries(data: bytes, sizes: Iterable[int]) -> Iterable[memoryview]:
+    view = memoryview(data)
+    offset = 0
+    for size in itertools.cycle(sizes):
+        if size <= 0:
+            raise ValueError("boundary sizes must be positive")
+        if offset >= len(view):
+            return
+        end = min(offset + size, len(view))
+        yield view[offset:end]
+        offset = end
+
+
+def seeded_boundaries(data: bytes) -> Iterable[memoryview]:
+    randomizer = random.Random(0)
+    view = memoryview(data)
+    offset = 0
+    while offset < len(view):
+        size = randomizer.randint(1, 128 * 1024)
+        end = min(offset + size, len(view))
+        yield view[offset:end]
+        offset = end
+
+
+@pytest.fixture(scope="module")
+def source_data() -> bytes:
+    return (b"rohmu decompression sink\n" * 65536) + bytes(range(256)) * 1024
+
+
+@pytest.mark.parametrize("algorithm", ("snappy", "zstd", "lzma"))
+@pytest.mark.parametrize("input_sizes", ((1,), (7,), (64 * 1024,), (1024 * 1024,)))
+def test_decompress_sink_preserves_data_across_input_boundaries(
+    algorithm: str, input_sizes: tuple[int, ...], source_data: bytes
+) -> None:
+    # Decompressed output must match the original when compressed input arrives in fixed-size chunks.
+    # Covers tiny (1 byte), small, and large (up to 1 MiB) write boundaries for each algorithm.
+    compressed = compress(algorithm, source_data)
+    sink = MeasuringSink()
+    decompressor = DecompressSink(sink, algorithm)
+
+    for chunk in boundaries(compressed, input_sizes):
+        assert decompressor.write(chunk) == len(chunk)
+
+    assert sink.total_written == len(source_data)
+    assert sink.digest.digest() == hashlib.sha256(source_data).digest()
+
+
+@pytest.mark.parametrize("algorithm", ("snappy", "zstd", "lzma"))
+def test_decompress_sink_preserves_data_across_seeded_boundaries(algorithm: str, source_data: bytes) -> None:
+    # Same correctness check as fixed boundaries, but with pseudo-random chunk sizes (seeded).
+    compressed = compress(algorithm, source_data)
+    sink = MeasuringSink()
+    decompressor = DecompressSink(sink, algorithm)
+
+    for chunk in seeded_boundaries(compressed):
+        assert decompressor.write(chunk) == len(chunk)
+
+    assert sink.total_written == len(source_data)
+    assert sink.digest.digest() == hashlib.sha256(source_data).digest()
+
+
+@pytest.mark.parametrize("algorithm", ("snappy", "zstd", "lzma"))
+def test_decompress_sink_retries_short_downstream_writes(algorithm: str, source_data: bytes) -> None:
+    # Downstream sink accepts only 37 KiB per write; Sink must retry until all decompressed bytes land.
+    compressed = compress(algorithm, source_data)
+    sink = ShortWriteSink(37 * 1024)
+
+    assert DecompressSink(sink, algorithm).write(compressed) == len(compressed)
+    assert sink.total_written == len(source_data)
+    assert sink.digest.digest() == hashlib.sha256(source_data).digest()
+
+
+@pytest.mark.parametrize("algorithm", ("zstd", "lzma"))
+def test_decompress_sink_bounds_output_writes(algorithm: str) -> None:
+    # Large input must be decompressed in multiple downstream writes, each no larger than OUTPUT_CHUNK_SIZE.
+    source = b"a" * (OUTPUT_CHUNK_SIZE * 4)
+    compressed = compress(algorithm, source)
+    sink = MeasuringSink()
+
+    assert DecompressSink(sink, algorithm).write(compressed) == len(compressed)
+    assert sink.total_written == len(source)
+    assert sink.write_count > 1
+    assert sink.max_write_size <= OUTPUT_CHUNK_SIZE
+
+
+def test_snappy_decompress_sink_bounds_decoder_input() -> None:
+    # Snappy slices compressed input at SNAPPY_INPUT_SLICE_SIZE; each slice's decompressed output stays bounded.
+    source = bytes(range(256)) * (32 * 1024)
+    compressed = compress("snappy", source)
+    sink = MeasuringSink()
+
+    assert len(compressed) > SNAPPY_INPUT_SLICE_SIZE
+    assert DecompressSink(sink, "snappy").write(memoryview(compressed)) == len(compressed)
+    assert sink.total_written == len(source)
+    assert sink.max_write_size <= SNAPPY_INPUT_SLICE_SIZE * 22
+
+
+@pytest.mark.parametrize(
+    ("algorithm", "expected_output"),
+    (("snappy", 327680), ("zstd", 262144), ("lzma", 340000)),
+)
+def test_decompress_sink_preserves_truncated_stream_behavior(algorithm: str, expected_output: int) -> None:
+    # Missing the final compressed byte emits partial output without raising (no explicit end-of-stream flush).
+    source = b"rohmu-truncation-" * 20000
+    compressed = compress(algorithm, source)
+    sink = MeasuringSink()
+
+    assert DecompressSink(sink, algorithm).write(compressed[:-1]) == len(compressed) - 1
+    assert sink.total_written == expected_output
+
+
+def test_decrypt_sink_then_decompress_sink_preserves_data(source_data: bytes) -> None:
+    # Pipeline integration: encrypted chunks → decrypt → decompress → verify full original via SHA-256.
+    compressed = compress("snappy", source_data)
+    key = bytes(range(32))
+    encryptor = SymmetricEncryptor(key)
+    encrypted = encryptor.update(compressed) + encryptor.finalize()
+    sink = MeasuringSink()
+    decrypt_sink = SymmetricDecryptSink(DecompressSink(sink, "snappy"), len(encrypted), key)
+
+    for chunk in seeded_boundaries(encrypted):
+        assert decrypt_sink.write(chunk) == len(chunk)
+
+    assert sink.total_written == len(source_data)
+    assert sink.digest.digest() == hashlib.sha256(source_data).digest()


### PR DESCRIPTION

DecompressSink previously ran each algorithm's decompressor in a single unbounded call per write(), so a single compressed chunk could produce an arbitrarily large decompressed output in one shot. Split the decompression logic into per-algorithm sink classes (snappy/lzma/zstd) that cap output at OUTPUT_CHUNK_SIZE and slice snappy input at SNAPPY_INPUT_SLICE_SIZE, writing through _write_to_next_sink incrementally instead of decompressing the whole input in one call.

[PGSQL-1193]

